### PR TITLE
feat: passive install tracking from update check requests

### DIFF
--- a/inc/class-passive-install-tracker.php
+++ b/inc/class-passive-install-tracker.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Passive Install Tracker
+ *
+ * Hooks into update check requests and logs lightweight data to the
+ * wp_wu_passive_installs table. Equivalent to server access-log level data.
+ *
+ * Data captured per check:
+ *  - IP address of the requesting site
+ *  - Site URL and WP version (parsed from WordPress User-Agent)
+ *  - Slug being checked
+ *  - Whether the request carried a valid OAuth token
+ *  - Timestamp (first_seen / last_seen with check_count increment)
+ *
+ * Reverse DNS resolution is deferred to a daily cron job to avoid blocking
+ * the update response.
+ *
+ * @package WP_Update_Server_Plugin
+ */
+
+namespace WP_Update_Server_Plugin;
+
+class Passive_Install_Tracker {
+
+	/**
+	 * Cron hook name for DNS backfill.
+	 *
+	 * @var string
+	 */
+	const CRON_DNS_BACKFILL = 'wu_passive_installs_dns_backfill';
+
+	/**
+	 * Cron hook name for record purge.
+	 *
+	 * @var string
+	 */
+	const CRON_PURGE = 'wu_passive_installs_purge';
+
+	/**
+	 * Constructor — registers hooks.
+	 */
+	public function __construct() {
+
+		// Hook into the update API request handler.
+		add_action('wu_before_update_api_response', [$this, 'track_update_check'], 10, 2);
+
+		// Schedule cron jobs.
+		add_action('admin_init', [$this, 'schedule_crons']);
+		add_action(self::CRON_DNS_BACKFILL, [$this, 'run_dns_backfill']);
+		add_action(self::CRON_PURGE, [$this, 'run_purge']);
+	}
+
+	/**
+	 * Record a passive install from an update check request.
+	 *
+	 * Called via the wu_before_update_api_response action fired from
+	 * Request_Endpoint::handleUpdateApiRequest() before the response is sent.
+	 *
+	 * @param string $slug            The plugin/addon slug being checked.
+	 * @param bool   $is_authenticated Whether the request carried a valid OAuth token.
+	 * @return void
+	 */
+	public function track_update_check(string $slug, bool $is_authenticated): void {
+
+		if (empty($slug)) {
+			return;
+		}
+
+		$ip_address = $this->get_client_ip();
+		$user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
+
+		[$site_url, $wp_version] = $this->parse_wordpress_user_agent($user_agent);
+
+		// Silently skip on failure — never block the update response.
+		Passive_Installs_Table::upsert(
+			$site_url,
+			$ip_address,
+			$slug,
+			$is_authenticated,
+			$wp_version,
+			$user_agent
+		);
+	}
+
+	/**
+	 * Parse the WordPress User-Agent header to extract site URL and WP version.
+	 *
+	 * WordPress sends: "WordPress/6.7.2; https://example.com"
+	 *
+	 * @param string $user_agent Raw User-Agent string.
+	 * @return array{0: string, 1: string} [site_url, wp_version]. Empty strings on parse failure.
+	 */
+	public function parse_wordpress_user_agent(string $user_agent): array {
+
+		if (empty($user_agent)) {
+			return ['', ''];
+		}
+
+		// Match "WordPress/X.Y.Z; https://..." pattern.
+		if (preg_match('/^WordPress\/([0-9.]+);\s*(https?:\/\/[^\s]+)/i', $user_agent, $matches)) {
+			$wp_version = sanitize_text_field($matches[1]);
+			$site_url   = esc_url_raw(rtrim($matches[2], '/'));
+
+			return [$site_url, $wp_version];
+		}
+
+		return ['', ''];
+	}
+
+	/**
+	 * Get the real client IP address, respecting common proxy headers.
+	 *
+	 * @return string IP address, or empty string if unavailable.
+	 */
+	protected function get_client_ip(): string {
+
+		// Ordered by reliability. Only trust forwarded headers if behind a known proxy.
+		$headers = [
+			'HTTP_CF_CONNECTING_IP', // Cloudflare
+			'HTTP_X_REAL_IP',        // nginx proxy
+			'HTTP_X_FORWARDED_FOR',  // standard proxy (may be comma-separated)
+			'REMOTE_ADDR',           // direct connection
+		];
+
+		foreach ($headers as $header) {
+			if ( ! empty($_SERVER[ $header ])) {
+				// X-Forwarded-For may contain a list; take the first (client) IP.
+				$ip = sanitize_text_field(wp_unslash($_SERVER[ $header ]));
+				$ip = trim(explode(',', $ip)[0]);
+
+				if (filter_var($ip, FILTER_VALIDATE_IP)) {
+					return $ip;
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Schedule the DNS backfill and purge cron jobs.
+	 *
+	 * @return void
+	 */
+	public function schedule_crons(): void {
+
+		if ( ! wp_next_scheduled(self::CRON_DNS_BACKFILL)) {
+			wp_schedule_event(time(), 'daily', self::CRON_DNS_BACKFILL);
+		}
+
+		if ( ! wp_next_scheduled(self::CRON_PURGE)) {
+			// Run purge weekly — no need for daily.
+			wp_schedule_event(time(), 'weekly', self::CRON_PURGE);
+		}
+	}
+
+	/**
+	 * Backfill domain names for IPs that haven't been resolved yet.
+	 *
+	 * Runs daily via cron. Processes up to 200 IPs per run to avoid timeouts.
+	 * Results are cached in the domain column; IPs that fail resolution are
+	 * left as NULL and retried on the next run.
+	 *
+	 * @return void
+	 */
+	public function run_dns_backfill(): void {
+
+		$ips = Passive_Installs_Table::get_ips_without_domain(200);
+
+		if (empty($ips)) {
+			return;
+		}
+
+		foreach ($ips as $ip) {
+			$domain = $this->reverse_dns_lookup($ip);
+
+			if ( ! empty($domain)) {
+				Passive_Installs_Table::update_domain_by_ip($ip, $domain);
+			}
+		}
+	}
+
+	/**
+	 * Perform a reverse DNS lookup for an IP address.
+	 *
+	 * Returns the hostname on success, or empty string on failure.
+	 * Uses gethostbyaddr() which is synchronous but acceptable in a cron context.
+	 *
+	 * @param string $ip The IP address to look up.
+	 * @return string Resolved hostname, or empty string.
+	 */
+	protected function reverse_dns_lookup(string $ip): string {
+
+		if (empty($ip) || ! filter_var($ip, FILTER_VALIDATE_IP)) {
+			return '';
+		}
+
+		// gethostbyaddr returns the IP unchanged on failure.
+		$host = gethostbyaddr($ip);
+
+		if ($host === $ip || $host === false) {
+			return '';
+		}
+
+		return sanitize_text_field($host);
+	}
+
+	/**
+	 * Purge records older than the retention window.
+	 *
+	 * @return void
+	 */
+	public function run_purge(): void {
+
+		$deleted = Passive_Installs_Table::purge_old_records();
+
+		if ($deleted > 0) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log(sprintf('Ultimate Multisite Passive Installs: Purged %d old records', $deleted));
+		}
+	}
+}

--- a/inc/class-passive-installs-table.php
+++ b/inc/class-passive-installs-table.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * Passive Installs Database Table
+ *
+ * Handles the custom database table for storing passive install tracking data
+ * captured from update check requests.
+ *
+ * @package WP_Update_Server_Plugin
+ */
+
+namespace WP_Update_Server_Plugin;
+
+class Passive_Installs_Table {
+
+	/**
+	 * Table name (without prefix).
+	 *
+	 * @var string
+	 */
+	const TABLE_NAME = 'wu_passive_installs';
+
+	/**
+	 * Auto-purge records older than this many months.
+	 *
+	 * @var int
+	 */
+	const PURGE_MONTHS = 12;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+
+		add_action('admin_init', [$this, 'maybe_create_table']);
+	}
+
+	/**
+	 * Get the full table name with prefix.
+	 *
+	 * @return string
+	 */
+	public static function get_table_name(): string {
+
+		global $wpdb;
+
+		return $wpdb->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Create the table if it doesn't exist.
+	 *
+	 * @return void
+	 */
+	public function maybe_create_table(): void {
+
+		global $wpdb;
+
+		$table_name      = self::get_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$table_exists = $wpdb->get_var(
+			$wpdb->prepare(
+				'SHOW TABLES LIKE %s',
+				$table_name
+			)
+		);
+
+		if ($table_exists === $table_name) {
+			return;
+		}
+
+		$sql = "CREATE TABLE {$table_name} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			site_url VARCHAR(255) NOT NULL,
+			ip_address VARCHAR(45) NOT NULL,
+			domain VARCHAR(255) DEFAULT NULL,
+			wp_version VARCHAR(20) DEFAULT NULL,
+			slug_requested VARCHAR(100) NOT NULL,
+			is_authenticated TINYINT(1) NOT NULL DEFAULT 0,
+			user_agent TEXT DEFAULT NULL,
+			first_seen DATETIME NOT NULL,
+			last_seen DATETIME NOT NULL,
+			check_count INT UNSIGNED NOT NULL DEFAULT 1,
+			PRIMARY KEY (id),
+			UNIQUE KEY site_url_slug (site_url(191), slug_requested),
+			KEY domain (domain(191)),
+			KEY last_seen (last_seen),
+			KEY is_authenticated (is_authenticated),
+			KEY slug_requested (slug_requested)
+		) {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		dbDelta($sql);
+	}
+
+	/**
+	 * Upsert a passive install record.
+	 *
+	 * On first encounter, inserts a new row. On subsequent checks from the same
+	 * (site_url, slug_requested) pair, updates last_seen and increments check_count.
+	 *
+	 * @param string $site_url       The site URL parsed from User-Agent or empty string.
+	 * @param string $ip_address     The requesting IP address.
+	 * @param string $slug_requested The plugin/addon slug being checked.
+	 * @param bool   $is_authenticated Whether the request carried a valid OAuth token.
+	 * @param string $wp_version     WordPress version parsed from User-Agent.
+	 * @param string $user_agent     Raw User-Agent header value.
+	 * @return int|false Inserted/updated row ID, or false on failure.
+	 */
+	public static function upsert(
+		string $site_url,
+		string $ip_address,
+		string $slug_requested,
+		bool $is_authenticated,
+		string $wp_version = '',
+		string $user_agent = ''
+	) {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+		$now        = current_time('mysql');
+
+		// Attempt INSERT first; on duplicate key update counters.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$table_name}
+					(site_url, ip_address, domain, wp_version, slug_requested, is_authenticated, user_agent, first_seen, last_seen, check_count)
+				VALUES
+					(%s, %s, NULL, %s, %s, %d, %s, %s, %s, 1)
+				ON DUPLICATE KEY UPDATE
+					last_seen = VALUES(last_seen),
+					check_count = check_count + 1,
+					is_authenticated = GREATEST(is_authenticated, VALUES(is_authenticated)),
+					user_agent = COALESCE(VALUES(user_agent), user_agent),
+					wp_version = COALESCE(NULLIF(VALUES(wp_version), ''), wp_version)",
+				$site_url,
+				$ip_address,
+				$wp_version ?: null,
+				$slug_requested,
+				$is_authenticated ? 1 : 0,
+				$user_agent ?: null,
+				$now,
+				$now
+			)
+		);
+
+		if (false === $result) {
+			return false;
+		}
+
+		// For INSERT: insert_id is the new row. For UPDATE: insert_id is 0 on some MySQL
+		// versions; fetch the actual row id.
+		if ($wpdb->insert_id > 0) {
+			return $wpdb->insert_id;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT id FROM {$table_name} WHERE site_url = %s AND slug_requested = %s LIMIT 1",
+				$site_url,
+				$slug_requested
+			)
+		);
+	}
+
+	/**
+	 * Update the domain field for a row identified by IP address (used by DNS backfill cron).
+	 *
+	 * @param string $ip_address The IP address to look up.
+	 * @param string $domain     The resolved domain name.
+	 * @return int Number of rows updated.
+	 */
+	public static function update_domain_by_ip(string $ip_address, string $domain): int {
+
+		global $wpdb;
+
+		return (int) $wpdb->update(
+			self::get_table_name(),
+			['domain' => $domain],
+			['ip_address' => $ip_address],
+			['%s'],
+			['%s']
+		);
+	}
+
+	/**
+	 * Get IPs that have no domain resolved yet (for DNS backfill).
+	 *
+	 * @param int $limit Maximum number of IPs to return.
+	 * @return string[] List of distinct IP addresses.
+	 */
+	public static function get_ips_without_domain(int $limit = 200): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT ip_address FROM {$table_name} WHERE domain IS NULL LIMIT %d",
+				$limit
+			)
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get unique install count (distinct site_url values).
+	 *
+	 * @param int|null $days Optional look-back window in days.
+	 * @return int
+	 */
+	public static function get_unique_install_count(?int $days = null): int {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+		$where      = '';
+
+		if ($days !== null) {
+			$where = $wpdb->prepare(
+				' WHERE last_seen >= DATE_SUB(NOW(), INTERVAL %d DAY)',
+				$days
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return (int) $wpdb->get_var("SELECT COUNT(DISTINCT site_url) FROM {$table_name}{$where}");
+	}
+
+	/**
+	 * Get unique install count for authenticated installs only.
+	 *
+	 * @param int|null $days Optional look-back window in days.
+	 * @return int
+	 */
+	public static function get_authenticated_install_count(?int $days = null): int {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+		$where      = 'WHERE is_authenticated = 1';
+
+		if ($days !== null) {
+			$where .= $wpdb->prepare(
+				' AND last_seen >= DATE_SUB(NOW(), INTERVAL %d DAY)',
+				$days
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return (int) $wpdb->get_var("SELECT COUNT(DISTINCT site_url) FROM {$table_name} {$where}");
+	}
+
+	/**
+	 * Get slug popularity (how many unique sites checked for each slug).
+	 *
+	 * @param int $days  Number of days to look back.
+	 * @param int $limit Maximum rows to return.
+	 * @return array Array of ['slug_requested' => string, 'unique_sites' => int].
+	 */
+	public static function get_slug_distribution(int $days = 30, int $limit = 50): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					slug_requested,
+					COUNT(DISTINCT site_url) AS unique_sites,
+					SUM(check_count) AS total_checks
+				FROM {$table_name}
+				WHERE last_seen >= DATE_SUB(NOW(), INTERVAL %d DAY)
+				GROUP BY slug_requested
+				ORDER BY unique_sites DESC
+				LIMIT %d",
+				$days,
+				$limit
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get WordPress version distribution from passive installs.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array Array of ['wp_version' => string, 'count' => int].
+	 */
+	public static function get_wp_version_distribution(int $days = 30): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					wp_version,
+					COUNT(DISTINCT site_url) AS count
+				FROM {$table_name}
+				WHERE wp_version IS NOT NULL
+				AND last_seen >= DATE_SUB(NOW(), INTERVAL %d DAY)
+				GROUP BY wp_version
+				ORDER BY count DESC",
+				$days
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get recent passive install records for the admin table view.
+	 *
+	 * @param int $limit  Number of records to return.
+	 * @param int $offset Pagination offset.
+	 * @return array
+	 */
+	public static function get_recent_installs(int $limit = 50, int $offset = 0): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					id,
+					site_url,
+					ip_address,
+					domain,
+					wp_version,
+					slug_requested,
+					is_authenticated,
+					first_seen,
+					last_seen,
+					check_count
+				FROM {$table_name}
+				ORDER BY last_seen DESC
+				LIMIT %d OFFSET %d",
+				$limit,
+				$offset
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Purge records older than PURGE_MONTHS months.
+	 *
+	 * @return int Number of deleted rows.
+	 */
+	public static function purge_old_records(): int {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return (int) $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table_name} WHERE last_seen < DATE_SUB(NOW(), INTERVAL %d MONTH)",
+				self::PURGE_MONTHS
+			)
+		);
+	}
+}

--- a/inc/class-request-endpoint.php
+++ b/inc/class-request-endpoint.php
@@ -27,14 +27,34 @@ class Request_Endpoint {
 
 	public function handleUpdateApiRequest() {
 		if ( get_query_var('update_action') ) {
+			$action = get_query_var('update_action');
+			$slug   = get_query_var('update_slug');
+
+			// Fire passive install tracking for metadata checks (not downloads).
+			// Downloads are authenticated separately; metadata checks are the
+			// primary signal for passive install detection.
+			if ('get_metadata' === $action && ! empty($slug)) {
+				$is_authenticated = (bool) apply_filters('determine_current_user', null);
+
+				/**
+				 * Fires before the update API response is sent.
+				 *
+				 * Used by Passive_Install_Tracker to log lightweight install data
+				 * without blocking the response.
+				 *
+				 * @param string $slug             The plugin/addon slug being checked.
+				 * @param bool   $is_authenticated Whether the request carries a valid auth token.
+				 */
+				do_action('wu_before_update_api_response', $slug, $is_authenticated);
+			}
+
 			$this->updateServer->handleRequest(array_merge(
 				$_GET,
 				[
-				'action' => get_query_var('update_action'),
-				'slug'   => get_query_var('update_slug'),
-			]
-			)
-			);
+					'action' => $action,
+					'slug'   => $slug,
+				]
+			));
 		}
 	}
 }

--- a/inc/class-telemetry-admin.php
+++ b/inc/class-telemetry-admin.php
@@ -79,6 +79,14 @@ class Telemetry_Admin {
 		$error_summary   = Telemetry_Table::get_error_summary($days);
 		$recent_errors   = Telemetry_Table::get_recent_errors(20);
 
+		// Passive install tracking data.
+		$passive_total         = Passive_Installs_Table::get_unique_install_count();
+		$passive_period        = Passive_Installs_Table::get_unique_install_count($days);
+		$passive_authenticated = Passive_Installs_Table::get_authenticated_install_count($days);
+		$passive_slugs         = Passive_Installs_Table::get_slug_distribution($days, 20);
+		$passive_wp_versions   = Passive_Installs_Table::get_wp_version_distribution($days);
+		$passive_recent        = Passive_Installs_Table::get_recent_installs(20);
+
 		?>
 		<div class="wrap wu-telemetry-dashboard">
 			<h1><?php esc_html_e('Ultimate Multisite Telemetry Dashboard', 'wp-update-server-plugin'); ?></h1>
@@ -105,7 +113,7 @@ class Telemetry_Admin {
 						<?php
 						printf(
 							/* translators: %d is the number of days */
-							esc_html__('in last %d days', 'wp-update-server-plugin'),
+							esc_html__('in last %d days (opt-in)', 'wp-update-server-plugin'),
 							esc_html($days)
 						);
 						?>
@@ -114,13 +122,159 @@ class Telemetry_Admin {
 				<div class="wu-telemetry-card">
 					<h3><?php esc_html_e('Total Sites Ever', 'wp-update-server-plugin'); ?></h3>
 					<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($total_sites)); ?></div>
-					<div class="wu-telemetry-card-label"><?php esc_html_e('all time', 'wp-update-server-plugin'); ?></div>
+					<div class="wu-telemetry-card-label"><?php esc_html_e('all time (opt-in)', 'wp-update-server-plugin'); ?></div>
+				</div>
+				<div class="wu-telemetry-card wu-telemetry-card--passive">
+					<h3><?php esc_html_e('Passive Installs', 'wp-update-server-plugin'); ?></h3>
+					<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($passive_period)); ?></div>
+					<div class="wu-telemetry-card-label">
+						<?php
+						printf(
+							/* translators: %d is the number of days */
+							esc_html__('unique sites in last %d days', 'wp-update-server-plugin'),
+							esc_html($days)
+						);
+						?>
+					</div>
+				</div>
+				<div class="wu-telemetry-card wu-telemetry-card--passive">
+					<h3><?php esc_html_e('Total Passive (All Time)', 'wp-update-server-plugin'); ?></h3>
+					<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($passive_total)); ?></div>
+					<div class="wu-telemetry-card-label"><?php esc_html_e('unique sites ever seen', 'wp-update-server-plugin'); ?></div>
+				</div>
+				<div class="wu-telemetry-card wu-telemetry-card--passive">
+					<h3><?php esc_html_e('Authenticated Passive', 'wp-update-server-plugin'); ?></h3>
+					<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($passive_authenticated)); ?></div>
+					<div class="wu-telemetry-card-label">
+						<?php
+						printf(
+							/* translators: %d is the number of days */
+							esc_html__('with valid token in last %d days', 'wp-update-server-plugin'),
+							esc_html($days)
+						);
+						?>
+					</div>
 				</div>
 				<div class="wu-telemetry-card">
 					<h3><?php esc_html_e('Error Reports', 'wp-update-server-plugin'); ?></h3>
 					<div class="wu-telemetry-card-value"><?php echo esc_html(count($recent_errors)); ?></div>
 					<div class="wu-telemetry-card-label"><?php esc_html_e('recent errors', 'wp-update-server-plugin'); ?></div>
 				</div>
+			</div>
+
+			<!-- Passive Install Tracking -->
+			<h2><?php esc_html_e('Passive Install Tracking', 'wp-update-server-plugin'); ?></h2>
+			<p class="description">
+				<?php esc_html_e('Recorded from update check requests (equivalent to server access log data). No opt-in required.', 'wp-update-server-plugin'); ?>
+			</p>
+
+			<div class="wu-telemetry-grid">
+				<!-- Slug Distribution -->
+				<div class="wu-telemetry-section">
+					<h2><?php esc_html_e('Addon/Plugin Checks', 'wp-update-server-plugin'); ?></h2>
+					<?php if ( ! empty($passive_slugs)) : ?>
+						<table class="wp-list-table widefat fixed striped">
+							<thead>
+								<tr>
+									<th><?php esc_html_e('Slug', 'wp-update-server-plugin'); ?></th>
+									<th><?php esc_html_e('Unique Sites', 'wp-update-server-plugin'); ?></th>
+									<th><?php esc_html_e('Total Checks', 'wp-update-server-plugin'); ?></th>
+								</tr>
+							</thead>
+							<tbody>
+								<?php foreach ($passive_slugs as $row) : ?>
+									<tr>
+										<td><code><?php echo esc_html($row['slug_requested']); ?></code></td>
+										<td><?php echo esc_html(number_format((int) $row['unique_sites'])); ?></td>
+										<td><?php echo esc_html(number_format((int) $row['total_checks'])); ?></td>
+									</tr>
+								<?php endforeach; ?>
+							</tbody>
+						</table>
+					<?php else : ?>
+						<p><?php esc_html_e('No passive install data yet. Data will appear once sites check for updates.', 'wp-update-server-plugin'); ?></p>
+					<?php endif; ?>
+				</div>
+
+				<!-- WP Version Distribution (Passive) -->
+				<div class="wu-telemetry-section">
+					<h2><?php esc_html_e('WordPress Versions (Passive)', 'wp-update-server-plugin'); ?></h2>
+					<?php if ( ! empty($passive_wp_versions)) : ?>
+						<table class="wp-list-table widefat fixed striped">
+							<thead>
+								<tr>
+									<th><?php esc_html_e('Version', 'wp-update-server-plugin'); ?></th>
+									<th><?php esc_html_e('Sites', 'wp-update-server-plugin'); ?></th>
+									<th><?php esc_html_e('Percentage', 'wp-update-server-plugin'); ?></th>
+								</tr>
+							</thead>
+							<tbody>
+								<?php foreach ($passive_wp_versions as $row) : ?>
+									<?php $pct = $passive_period > 0 ? round(((int) $row['count'] / $passive_period) * 100, 1) : 0; ?>
+									<tr>
+										<td><?php echo esc_html($row['wp_version']); ?></td>
+										<td><?php echo esc_html($row['count']); ?></td>
+										<td>
+											<div class="wu-telemetry-bar" style="width: <?php echo esc_attr($pct); ?>%;"></div>
+											<?php echo esc_html($pct); ?>%
+										</td>
+									</tr>
+								<?php endforeach; ?>
+							</tbody>
+						</table>
+					<?php else : ?>
+						<p><?php esc_html_e('No data available.', 'wp-update-server-plugin'); ?></p>
+					<?php endif; ?>
+				</div>
+			</div>
+
+			<!-- Recent Passive Installs -->
+			<div class="wu-telemetry-section wu-telemetry-full-width" style="margin-bottom: 20px;">
+				<h2><?php esc_html_e('Recent Passive Installs', 'wp-update-server-plugin'); ?></h2>
+				<?php if ( ! empty($passive_recent)) : ?>
+					<table class="wp-list-table widefat fixed striped">
+						<thead>
+							<tr>
+								<th style="width: 20%;"><?php esc_html_e('Site URL', 'wp-update-server-plugin'); ?></th>
+								<th style="width: 12%;"><?php esc_html_e('IP / Domain', 'wp-update-server-plugin'); ?></th>
+								<th style="width: 8%;"><?php esc_html_e('WP Version', 'wp-update-server-plugin'); ?></th>
+								<th style="width: 15%;"><?php esc_html_e('Slug', 'wp-update-server-plugin'); ?></th>
+								<th style="width: 8%;"><?php esc_html_e('Auth', 'wp-update-server-plugin'); ?></th>
+								<th style="width: 12%;"><?php esc_html_e('First Seen', 'wp-update-server-plugin'); ?></th>
+								<th style="width: 12%;"><?php esc_html_e('Last Seen', 'wp-update-server-plugin'); ?></th>
+								<th style="width: 8%;"><?php esc_html_e('Checks', 'wp-update-server-plugin'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($passive_recent as $row) : ?>
+								<tr>
+									<td><?php echo esc_html($row['site_url'] ?: '—'); ?></td>
+									<td>
+										<?php if ( ! empty($row['domain'])) : ?>
+											<?php echo esc_html($row['domain']); ?>
+										<?php else : ?>
+											<code><?php echo esc_html($row['ip_address']); ?></code>
+										<?php endif; ?>
+									</td>
+									<td><?php echo esc_html($row['wp_version'] ?: '—'); ?></td>
+									<td><code><?php echo esc_html($row['slug_requested']); ?></code></td>
+									<td>
+										<?php if ($row['is_authenticated']) : ?>
+											<span class="wu-badge wu-badge--yes"><?php esc_html_e('Yes', 'wp-update-server-plugin'); ?></span>
+										<?php else : ?>
+											<span class="wu-badge wu-badge--no"><?php esc_html_e('No', 'wp-update-server-plugin'); ?></span>
+										<?php endif; ?>
+									</td>
+									<td><?php echo esc_html($row['first_seen']); ?></td>
+									<td><?php echo esc_html($row['last_seen']); ?></td>
+									<td><?php echo esc_html(number_format((int) $row['check_count'])); ?></td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				<?php else : ?>
+					<p><?php esc_html_e('No passive install records yet.', 'wp-update-server-plugin'); ?></p>
+				<?php endif; ?>
 			</div>
 
 			<div class="wu-telemetry-grid">
@@ -367,6 +521,7 @@ class Telemetry_Admin {
 			}
 			.wu-telemetry-cards {
 				display: flex;
+				flex-wrap: wrap;
 				gap: 20px;
 				margin-bottom: 30px;
 			}
@@ -376,7 +531,15 @@ class Telemetry_Admin {
 				border-radius: 4px;
 				padding: 20px;
 				flex: 1;
+				min-width: 160px;
 				text-align: center;
+			}
+			.wu-telemetry-card--passive {
+				border-color: #00a32a;
+				background: #f0fdf4;
+			}
+			.wu-telemetry-card--passive .wu-telemetry-card-value {
+				color: #00a32a;
 			}
 			.wu-telemetry-card h3 {
 				margin: 0 0 10px;
@@ -418,6 +581,22 @@ class Telemetry_Admin {
 				display: inline-block;
 				margin-right: 8px;
 				min-width: 2px;
+			}
+			.wu-badge {
+				display: inline-block;
+				padding: 2px 8px;
+				border-radius: 3px;
+				font-size: 11px;
+				font-weight: 600;
+				text-transform: uppercase;
+			}
+			.wu-badge--yes {
+				background: #d1fae5;
+				color: #065f46;
+			}
+			.wu-badge--no {
+				background: #f3f4f6;
+				color: #6b7280;
 			}
 		</style>
 		<?php

--- a/wp-update-server-plugin.php
+++ b/wp-update-server-plugin.php
@@ -16,6 +16,8 @@ require_once __DIR__ . '/inc/class-store-api.php';
 require_once __DIR__ . '/inc/class-telemetry-table.php';
 require_once __DIR__ . '/inc/class-telemetry-receiver.php';
 require_once __DIR__ . '/inc/class-telemetry-admin.php';
+require_once __DIR__ . '/inc/class-passive-installs-table.php';
+require_once __DIR__ . '/inc/class-passive-install-tracker.php';
 require_once __DIR__ . '/inc/class-composer-token-table.php';
 require_once __DIR__ . '/inc/class-composer-token.php';
 require_once __DIR__ . '/inc/class-product-versions.php';
@@ -31,6 +33,10 @@ $wp_update_server_plugin_store_api        = new \WP_Update_Server_Plugin\Store_A
 $wp_update_server_plugin_telemetry_table    = new \WP_Update_Server_Plugin\Telemetry_Table();
 $wp_update_server_plugin_telemetry_receiver = new \WP_Update_Server_Plugin\Telemetry_Receiver();
 $wp_update_server_plugin_telemetry_admin    = new \WP_Update_Server_Plugin\Telemetry_Admin();
+
+// Passive install tracking components
+$wp_update_server_plugin_passive_installs_table  = new \WP_Update_Server_Plugin\Passive_Installs_Table();
+$wp_update_server_plugin_passive_install_tracker = new \WP_Update_Server_Plugin\Passive_Install_Tracker();
 
 // Composer repository components
 $wp_update_server_plugin_composer_token_table = new \WP_Update_Server_Plugin\Composer_Token_Table();


### PR DESCRIPTION
## Summary

Implements passive install tracking as specified in #3. Every update check request to `?update_action=get_metadata` now creates or updates a record in `wp_wu_passive_installs` — no opt-in required, equivalent to server access log data.

Closes #3

## What was implemented

- **`Passive_Installs_Table`** — new DB table `wp_wu_passive_installs` with upsert on `(site_url, slug_requested)`. Increments `check_count` and updates `last_seen` on repeat checks. Includes query methods for dashboard stats.
- **`Passive_Install_Tracker`** — hooks `wu_before_update_api_response` action to log: IP address, site URL + WP version (parsed from `WordPress/X.Y; https://...` User-Agent), slug requested, and whether the request carried a valid OAuth token. DNS resolution is deferred to a daily cron job (backfills up to 200 IPs/run). Weekly purge cron enforces 12-month retention.
- **`Request_Endpoint::handleUpdateApiRequest()`** — fires `wu_before_update_api_response` action on `get_metadata` requests before delegating to the update server.
- **`Telemetry_Admin` dashboard** — new passive install cards (total all-time, period unique, authenticated), slug distribution table, WP version breakdown from passive data, and a recent installs table with domain/IP, auth badge, and check count.

## Data model

```sql
CREATE TABLE wp_wu_passive_installs (
    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
    site_url VARCHAR(255) NOT NULL,
    ip_address VARCHAR(45) NOT NULL,
    domain VARCHAR(255) DEFAULT NULL,
    wp_version VARCHAR(20) DEFAULT NULL,
    slug_requested VARCHAR(100) NOT NULL,
    is_authenticated TINYINT(1) NOT NULL DEFAULT 0,
    user_agent TEXT DEFAULT NULL,
    first_seen DATETIME NOT NULL,
    last_seen DATETIME NOT NULL,
    check_count INT UNSIGNED NOT NULL DEFAULT 1,
    UNIQUE KEY site_url_slug (site_url(191), slug_requested),
    KEY domain, KEY last_seen, KEY is_authenticated, KEY slug_requested
);
```

## Design decisions

- **Upsert not insert** — one row per `(site_url, slug)` pair; `check_count` tracks frequency
- **Non-blocking** — tracker fires before response but DB write is synchronous/lightweight; DNS is async via cron
- **Auth escalation** — `is_authenticated` uses `GREATEST()` so a row that was anonymous becomes authenticated if the same site later sends a token
- **Privacy** — access-log level data only; 12-month auto-purge; no PII beyond IP/domain/site URL (which WordPress voluntarily sends in User-Agent)

## Runtime Testing

- **Risk classification:** Medium (new DB table + hook in request path)
- **Testing level:** self-assessed (no local WP dev environment available)
- **Code review:** Logic verified against existing `Telemetry_Table` patterns; SQL upsert syntax verified against MySQL `ON DUPLICATE KEY UPDATE` spec
- **Gap:** Runtime verification (actual update check hitting the endpoint) requires a live WP install — recommend smoke test on staging before merge to main