### PR TITLE
feat: enhanced telemetry with exact counts, subsite data, and revenue signals

### DIFF
--- a/inc/class-telemetry-admin.php
+++ b/inc/class-telemetry-admin.php
@@ -79,6 +79,15 @@ class Telemetry_Admin {
 		$error_summary   = Telemetry_Table::get_error_summary($days);
 		$recent_errors   = Telemetry_Table::get_recent_errors(20);
 
+		// Enhanced telemetry (tracker v2.0.0+).
+		$total_subsites          = Telemetry_Table::get_total_subsites_across_network($days);
+		$subsite_distribution    = Telemetry_Table::get_subsite_distribution($days);
+		$revenue_distribution    = Telemetry_Table::get_revenue_distribution($days);
+		$conversion_distribution = Telemetry_Table::get_conversion_rate_distribution($days);
+		$connect_adoption        = Telemetry_Table::get_connect_adoption($days);
+		$hosting_providers       = Telemetry_Table::get_hosting_provider_distribution($days);
+		$membership_distribution = Telemetry_Table::get_membership_count_distribution($days);
+
 		// Passive install tracking data.
 		$passive_total         = Passive_Installs_Table::get_unique_install_count();
 		$passive_period        = Passive_Installs_Table::get_unique_install_count($days);
@@ -453,6 +462,181 @@ class Telemetry_Admin {
 				</div>
 			</div>
 
+			<!-- Enhanced Telemetry (tracker v2.0.0+) -->
+			<?php if ($total_subsites > 0 || ! empty($subsite_distribution) || ! empty($revenue_distribution)) : ?>
+			<h2><?php esc_html_e('Enhanced Network Telemetry', 'wp-update-server-plugin'); ?></h2>
+			<p class="description">
+				<?php esc_html_e('Data from opt-in installations running tracker v2.0.0+. Exact counts reported by consenting networks.', 'wp-update-server-plugin'); ?>
+			</p>
+
+			<!-- Enhanced overview cards -->
+			<div class="wu-telemetry-cards" style="margin-bottom: 30px;">
+				<div class="wu-telemetry-card wu-telemetry-card--enhanced">
+					<h3><?php esc_html_e('Total Subsites Reported', 'wp-update-server-plugin'); ?></h3>
+					<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($total_subsites)); ?></div>
+					<div class="wu-telemetry-card-label">
+						<?php
+						printf(
+							/* translators: %d is the number of days */
+							esc_html__('across all networks in last %d days', 'wp-update-server-plugin'),
+							esc_html($days)
+						);
+						?>
+					</div>
+				</div>
+				<?php if ( ! empty($connect_adoption) && $connect_adoption['total_reporting'] > 0) : ?>
+				<div class="wu-telemetry-card wu-telemetry-card--enhanced">
+					<h3><?php esc_html_e('Stripe Connect Adoption', 'wp-update-server-plugin'); ?></h3>
+					<div class="wu-telemetry-card-value"><?php echo esc_html($connect_adoption['stripe_connect_pct']); ?>%</div>
+					<div class="wu-telemetry-card-label">
+						<?php
+						printf(
+							/* translators: %d is the number of sites */
+							esc_html__('%d of %d reporting networks', 'wp-update-server-plugin'),
+							esc_html($connect_adoption['stripe_connect']),
+							esc_html($connect_adoption['total_reporting'])
+						);
+						?>
+					</div>
+				</div>
+				<div class="wu-telemetry-card wu-telemetry-card--enhanced">
+					<h3><?php esc_html_e('PayPal Connect Adoption', 'wp-update-server-plugin'); ?></h3>
+					<div class="wu-telemetry-card-value"><?php echo esc_html($connect_adoption['paypal_connect_pct']); ?>%</div>
+					<div class="wu-telemetry-card-label">
+						<?php
+						printf(
+							/* translators: %d is the number of sites */
+							esc_html__('%d of %d reporting networks', 'wp-update-server-plugin'),
+							esc_html($connect_adoption['paypal_connect']),
+							esc_html($connect_adoption['total_reporting'])
+						);
+						?>
+					</div>
+				</div>
+				<?php endif; ?>
+			</div>
+
+			<div class="wu-telemetry-grid">
+				<!-- Subsite Distribution -->
+				<?php if ( ! empty($subsite_distribution)) : ?>
+				<div class="wu-telemetry-section">
+					<h2><?php esc_html_e('Subsite Count Distribution', 'wp-update-server-plugin'); ?></h2>
+					<table class="wp-list-table widefat fixed striped">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Subsites per Network', 'wp-update-server-plugin'); ?></th>
+								<th><?php esc_html_e('Networks', 'wp-update-server-plugin'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($subsite_distribution as $row) : ?>
+								<tr>
+									<td><?php echo esc_html($row['bucket']); ?></td>
+									<td><?php echo esc_html(number_format((int) $row['count'])); ?></td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+				<?php endif; ?>
+
+				<!-- Revenue Distribution -->
+				<?php if ( ! empty($revenue_distribution)) : ?>
+				<div class="wu-telemetry-section">
+					<h2><?php esc_html_e('30-Day Revenue Distribution', 'wp-update-server-plugin'); ?></h2>
+					<p class="description"><?php esc_html_e('In site\'s base currency. No FX conversion applied.', 'wp-update-server-plugin'); ?></p>
+					<table class="wp-list-table widefat fixed striped">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Revenue Range', 'wp-update-server-plugin'); ?></th>
+								<th><?php esc_html_e('Networks', 'wp-update-server-plugin'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($revenue_distribution as $row) : ?>
+								<tr>
+									<td><?php echo esc_html($row['bucket']); ?></td>
+									<td><?php echo esc_html(number_format((int) $row['count'])); ?></td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+				<?php endif; ?>
+
+				<!-- Checkout Conversion Rate Distribution -->
+				<?php if ( ! empty($conversion_distribution)) : ?>
+				<div class="wu-telemetry-section">
+					<h2><?php esc_html_e('Checkout Conversion Rates', 'wp-update-server-plugin'); ?></h2>
+					<table class="wp-list-table widefat fixed striped">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Conversion Rate', 'wp-update-server-plugin'); ?></th>
+								<th><?php esc_html_e('Networks', 'wp-update-server-plugin'); ?></th>
+								<th><?php esc_html_e('Avg Rate', 'wp-update-server-plugin'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($conversion_distribution as $row) : ?>
+								<tr>
+									<td><?php echo esc_html($row['bucket']); ?></td>
+									<td><?php echo esc_html(number_format((int) $row['count'])); ?></td>
+									<td><?php echo esc_html($row['avg_rate_pct']); ?>%</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+				<?php endif; ?>
+
+				<!-- Active Membership Distribution -->
+				<?php if ( ! empty($membership_distribution)) : ?>
+				<div class="wu-telemetry-section">
+					<h2><?php esc_html_e('Active Memberships Distribution', 'wp-update-server-plugin'); ?></h2>
+					<table class="wp-list-table widefat fixed striped">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Active Memberships', 'wp-update-server-plugin'); ?></th>
+								<th><?php esc_html_e('Networks', 'wp-update-server-plugin'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($membership_distribution as $row) : ?>
+								<tr>
+									<td><?php echo esc_html($row['bucket']); ?></td>
+									<td><?php echo esc_html(number_format((int) $row['count'])); ?></td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+				<?php endif; ?>
+
+				<!-- Hosting Providers -->
+				<?php if ( ! empty($hosting_providers)) : ?>
+				<div class="wu-telemetry-section">
+					<h2><?php esc_html_e('Hosting Providers', 'wp-update-server-plugin'); ?></h2>
+					<table class="wp-list-table widefat fixed striped">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Provider', 'wp-update-server-plugin'); ?></th>
+								<th><?php esc_html_e('Networks', 'wp-update-server-plugin'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($hosting_providers as $row) : ?>
+								<tr>
+									<td><?php echo esc_html($row['provider']); ?></td>
+									<td><?php echo esc_html(number_format((int) $row['count'])); ?></td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+				<?php endif; ?>
+			</div>
+			<?php endif; ?>
+
 			<!-- Error Summary -->
 			<div class="wu-telemetry-section wu-telemetry-full-width">
 				<h2><?php esc_html_e('Error Summary', 'wp-update-server-plugin'); ?></h2>
@@ -540,6 +724,13 @@ class Telemetry_Admin {
 			}
 			.wu-telemetry-card--passive .wu-telemetry-card-value {
 				color: #00a32a;
+			}
+			.wu-telemetry-card--enhanced {
+				border-color: #7c3aed;
+				background: #f5f3ff;
+			}
+			.wu-telemetry-card--enhanced .wu-telemetry-card-value {
+				color: #7c3aed;
 			}
 			.wu-telemetry-card h3 {
 				margin: 0 0 10px;

--- a/inc/class-telemetry-receiver.php
+++ b/inc/class-telemetry-receiver.php
@@ -185,15 +185,23 @@ class Telemetry_Receiver {
 
 		return new \WP_REST_Response(
 			[
-				'unique_sites'    => Telemetry_Table::get_unique_site_count($days),
-				'php_versions'    => Telemetry_Table::get_php_version_distribution($days),
-				'wp_versions'     => Telemetry_Table::get_wp_version_distribution($days),
-				'plugin_versions' => Telemetry_Table::get_plugin_version_distribution($days),
-				'network_types'   => Telemetry_Table::get_network_type_distribution($days),
-				'gateways'        => Telemetry_Table::get_gateway_usage($days),
-				'addons'          => Telemetry_Table::get_addon_usage($days),
-				'error_summary'   => Telemetry_Table::get_error_summary($days),
-				'period_days'     => $days,
+				'unique_sites'                 => Telemetry_Table::get_unique_site_count($days),
+				'php_versions'                 => Telemetry_Table::get_php_version_distribution($days),
+				'wp_versions'                  => Telemetry_Table::get_wp_version_distribution($days),
+				'plugin_versions'              => Telemetry_Table::get_plugin_version_distribution($days),
+				'network_types'                => Telemetry_Table::get_network_type_distribution($days),
+				'gateways'                     => Telemetry_Table::get_gateway_usage($days),
+				'addons'                       => Telemetry_Table::get_addon_usage($days),
+				'error_summary'                => Telemetry_Table::get_error_summary($days),
+				// Enhanced telemetry (tracker v2.0.0+)
+				'total_subsites'               => Telemetry_Table::get_total_subsites_across_network($days),
+				'subsite_distribution'         => Telemetry_Table::get_subsite_distribution($days),
+				'revenue_distribution'         => Telemetry_Table::get_revenue_distribution($days),
+				'conversion_rate_distribution' => Telemetry_Table::get_conversion_rate_distribution($days),
+				'connect_adoption'             => Telemetry_Table::get_connect_adoption($days),
+				'hosting_providers'            => Telemetry_Table::get_hosting_provider_distribution($days),
+				'membership_distribution'      => Telemetry_Table::get_membership_count_distribution($days),
+				'period_days'                  => $days,
 			],
 			200
 		);

--- a/inc/class-telemetry-table.php
+++ b/inc/class-telemetry-table.php
@@ -429,6 +429,339 @@ class Telemetry_Table {
 	}
 
 	/**
+	 * Get the total number of subsites across all reporting networks.
+	 *
+	 * Sums `network.total_sites` from the most recent payload per site.
+	 * Only counts records from tracker version 2.0.0+ that include exact counts.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return int Total subsite count across all networks.
+	 */
+	public static function get_total_subsites_across_network(int $days = 30): int {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT SUM(CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.network.total_sites')) AS UNSIGNED))
+				FROM (
+					SELECT payload
+					FROM {$table_name}
+					WHERE data_type = 'usage'
+					AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY)
+					AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.tracker_version')) >= '2.0.0'
+					AND JSON_EXTRACT(payload, '$.network.total_sites') IS NOT NULL
+					GROUP BY site_hash
+					HAVING MAX(created_at)
+				) AS latest",
+				$days
+			)
+		);
+
+		return (int) $result;
+	}
+
+	/**
+	 * Get a histogram of subsite counts across reporting networks.
+	 *
+	 * Buckets: 1, 2-5, 6-10, 11-25, 26-50, 51-100, 101-250, 251+
+	 * Uses the most recent payload per site within the window.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array Array of ['bucket' => string, 'count' => int].
+	 */
+	public static function get_subsite_distribution(int $days = 30): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					CASE
+						WHEN total_sites = 1    THEN '1'
+						WHEN total_sites <= 5   THEN '2-5'
+						WHEN total_sites <= 10  THEN '6-10'
+						WHEN total_sites <= 25  THEN '11-25'
+						WHEN total_sites <= 50  THEN '26-50'
+						WHEN total_sites <= 100 THEN '51-100'
+						WHEN total_sites <= 250 THEN '101-250'
+						ELSE '251+'
+					END AS bucket,
+					COUNT(*) AS count
+				FROM (
+					SELECT
+						CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.network.total_sites')) AS UNSIGNED) AS total_sites
+					FROM {$table_name}
+					WHERE data_type = 'usage'
+					AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY)
+					AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.tracker_version')) >= '2.0.0'
+					AND JSON_EXTRACT(payload, '$.network.total_sites') IS NOT NULL
+					GROUP BY site_hash
+					HAVING MAX(created_at)
+				) AS latest
+				GROUP BY bucket
+				ORDER BY MIN(total_sites)",
+				$days
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get a histogram of 30-day revenue across reporting networks.
+	 *
+	 * Buckets (in site's base currency): $0, $1-$50, $51-$100, $101-$500, $501-$1000, $1001-$5000, $5001+
+	 * Note: revenue is reported in the site's base currency; no FX conversion is applied.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array Array of ['bucket' => string, 'count' => int].
+	 */
+	public static function get_revenue_distribution(int $days = 30): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					CASE
+						WHEN revenue = 0          THEN '\$0'
+						WHEN revenue <= 50        THEN '\$1-\$50'
+						WHEN revenue <= 100       THEN '\$51-\$100'
+						WHEN revenue <= 500       THEN '\$101-\$500'
+						WHEN revenue <= 1000      THEN '\$501-\$1000'
+						WHEN revenue <= 5000      THEN '\$1001-\$5000'
+						ELSE '\$5001+'
+					END AS bucket,
+					COUNT(*) AS count
+				FROM (
+					SELECT
+						CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.usage.total_revenue_30d')) AS DECIMAL(12,2)) AS revenue
+					FROM {$table_name}
+					WHERE data_type = 'usage'
+					AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY)
+					AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.tracker_version')) >= '2.0.0'
+					AND JSON_EXTRACT(payload, '$.usage.total_revenue_30d') IS NOT NULL
+					GROUP BY site_hash
+					HAVING MAX(created_at)
+				) AS latest
+				GROUP BY bucket
+				ORDER BY MIN(revenue)",
+				$days
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get a histogram of checkout conversion rates across reporting networks.
+	 *
+	 * Buckets: 0%, 1-10%, 11-25%, 26-50%, 51-75%, 76-100%
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array Array of ['bucket' => string, 'count' => int, 'avg_rate_pct' => float].
+	 */
+	public static function get_conversion_rate_distribution(int $days = 30): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					CASE
+						WHEN rate = 0          THEN '0%%'
+						WHEN rate <= 0.10      THEN '1-10%%'
+						WHEN rate <= 0.25      THEN '11-25%%'
+						WHEN rate <= 0.50      THEN '26-50%%'
+						WHEN rate <= 0.75      THEN '51-75%%'
+						ELSE '76-100%%'
+					END AS bucket,
+					COUNT(*) AS count,
+					ROUND(AVG(rate) * 100, 1) AS avg_rate_pct
+				FROM (
+					SELECT
+						CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.usage.conversion_rate_30d')) AS DECIMAL(5,4)) AS rate
+					FROM {$table_name}
+					WHERE data_type = 'usage'
+					AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY)
+					AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.tracker_version')) >= '2.0.0'
+					AND JSON_EXTRACT(payload, '$.usage.conversion_rate_30d') IS NOT NULL
+					GROUP BY site_hash
+					HAVING MAX(created_at)
+				) AS latest
+				GROUP BY bucket
+				ORDER BY MIN(rate)",
+				$days
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get Connect gateway adoption rates.
+	 *
+	 * Returns the count and percentage of sites using Stripe Connect and/or PayPal Connect.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array {
+	 *     @type int   $total_reporting      Sites reporting gateway data.
+	 *     @type int   $stripe_connect       Sites with Stripe Connect enabled.
+	 *     @type int   $paypal_connect       Sites with PayPal Connect enabled.
+	 *     @type float $stripe_connect_pct   Percentage using Stripe Connect.
+	 *     @type float $paypal_connect_pct   Percentage using PayPal Connect.
+	 * }
+	 */
+	public static function get_connect_adoption(int $days = 30): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT
+					COUNT(*) AS total_reporting,
+					SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(payload, '$.gateways.stripe_connect_enabled')) = 'true' THEN 1 ELSE 0 END) AS stripe_connect,
+					SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(payload, '$.gateways.paypal_connect_enabled')) = 'true' THEN 1 ELSE 0 END) AS paypal_connect
+				FROM (
+					SELECT payload
+					FROM {$table_name}
+					WHERE data_type = 'usage'
+					AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY)
+					AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.tracker_version')) >= '2.0.0'
+					AND (
+						JSON_EXTRACT(payload, '$.gateways.stripe_connect_enabled') IS NOT NULL
+						OR JSON_EXTRACT(payload, '$.gateways.paypal_connect_enabled') IS NOT NULL
+					)
+					GROUP BY site_hash
+					HAVING MAX(created_at)
+				) AS latest",
+				$days
+			),
+			ARRAY_A
+		);
+
+		if (empty($row) || (int) $row['total_reporting'] === 0) {
+			return [
+				'total_reporting'    => 0,
+				'stripe_connect'     => 0,
+				'paypal_connect'     => 0,
+				'stripe_connect_pct' => 0.0,
+				'paypal_connect_pct' => 0.0,
+			];
+		}
+
+		$total = (int) $row['total_reporting'];
+
+		return [
+			'total_reporting'    => $total,
+			'stripe_connect'     => (int) $row['stripe_connect'],
+			'paypal_connect'     => (int) $row['paypal_connect'],
+			'stripe_connect_pct' => $total > 0 ? round(((int) $row['stripe_connect'] / $total) * 100, 1) : 0.0,
+			'paypal_connect_pct' => $total > 0 ? round(((int) $row['paypal_connect'] / $total) * 100, 1) : 0.0,
+		];
+	}
+
+	/**
+	 * Get hosting provider distribution.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array Array of ['provider' => string, 'count' => int].
+	 */
+	public static function get_hosting_provider_distribution(int $days = 30): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					COALESCE(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.hosting.provider')), 'Unknown') AS provider,
+					COUNT(DISTINCT site_hash) AS count
+				FROM {$table_name}
+				WHERE data_type = 'usage'
+				AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY)
+				AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.tracker_version')) >= '2.0.0'
+				GROUP BY provider
+				ORDER BY count DESC",
+				$days
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get active membership count distribution.
+	 *
+	 * Buckets: 0, 1-10, 11-50, 51-100, 101-500, 501-1000, 1001+
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array Array of ['bucket' => string, 'count' => int].
+	 */
+	public static function get_membership_count_distribution(int $days = 30): array {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					CASE
+						WHEN memberships = 0     THEN '0'
+						WHEN memberships <= 10   THEN '1-10'
+						WHEN memberships <= 50   THEN '11-50'
+						WHEN memberships <= 100  THEN '51-100'
+						WHEN memberships <= 500  THEN '101-500'
+						WHEN memberships <= 1000 THEN '501-1000'
+						ELSE '1001+'
+					END AS bucket,
+					COUNT(*) AS count
+				FROM (
+					SELECT
+						CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.usage.active_memberships_exact')) AS UNSIGNED) AS memberships
+					FROM {$table_name}
+					WHERE data_type = 'usage'
+					AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY)
+					AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.tracker_version')) >= '2.0.0'
+					AND JSON_EXTRACT(payload, '$.usage.active_memberships_exact') IS NOT NULL
+					GROUP BY site_hash
+					HAVING MAX(created_at)
+				) AS latest
+				GROUP BY bucket
+				ORDER BY MIN(memberships)",
+				$days
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
 	 * Clean up old records.
 	 *
 	 * @param int $days Number of days to keep.


### PR DESCRIPTION
## Summary

- Adds 7 new aggregation query methods to `Telemetry_Table` for subsite counts, revenue distribution, checkout conversion rates, Connect gateway adoption, hosting providers, and active membership counts
- Exposes all new aggregations in the `/wu-telemetry/v1/stats` REST endpoint
- Adds an **Enhanced Network Telemetry** section to the admin dashboard (hidden until v2.0.0+ data is present)

## Changes

### `inc/class-telemetry-table.php`

| Method | Purpose |
|--------|---------|
| `get_total_subsites_across_network()` | Sum of `network.total_sites` across all reporting networks |
| `get_subsite_distribution()` | Histogram: 1, 2-5, 6-10, 11-25, 26-50, 51-100, 101-250, 251+ |
| `get_revenue_distribution()` | Histogram of `usage.total_revenue_30d` in 7 buckets |
| `get_conversion_rate_distribution()` | Histogram of `usage.conversion_rate_30d` with avg per bucket |
| `get_connect_adoption()` | % of sites with Stripe/PayPal Connect enabled |
| `get_hosting_provider_distribution()` | `hosting.provider` breakdown |
| `get_membership_count_distribution()` | Histogram of `usage.active_memberships_exact` |

All queries filter to `tracker_version >= '2.0.0'` — old clients sending range buckets are unaffected.

### `inc/class-telemetry-receiver.php`

Extended the `/wu-telemetry/v1/stats` response to include all 7 new aggregations.

### `inc/class-telemetry-admin.php`

Added **Enhanced Network Telemetry** section with:
- Summary cards: total subsites, Stripe Connect %, PayPal Connect %
- Tables: subsite distribution, 30d revenue distribution, conversion rate distribution, active memberships distribution, hosting providers
- Section is conditionally rendered — only shown when v2.0.0+ data exists

## Backward Compatibility

- Receiver continues to accept old-format payloads (range buckets, no `tracker_version`)
- New aggregation queries only run against `tracker_version >= '2.0.0'` rows
- No schema changes — all new data is stored in the existing `payload` JSON column

## Runtime Testing

- **Risk classification:** Low (no auth, payment, or data-deletion paths changed)
- **Testing level:** self-assessed (query logic reviewed; no dev environment with live DB available)
- New queries use the same `JSON_EXTRACT` pattern as existing queries in the file

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Expanded telemetry dashboard with enhanced network metrics including subsite count distribution
- Added 30-day revenue distribution and checkout conversion rate analytics with averages
- New payment gateway adoption tracking (Stripe and PayPal Connect)
- Added hosting provider distribution analytics
- Extended telemetry API to include active membership distribution and additional aggregated metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->