### PR TITLE
feat: PayPal Connect transaction analytics

### DIFF
--- a/inc/class-paypal-connect.php
+++ b/inc/class-paypal-connect.php
@@ -114,7 +114,7 @@ class PayPal_Connect {
 	 * @param bool $test_mode Whether to use sandbox.
 	 * @return string
 	 */
-	protected function get_api_base_url(bool $test_mode): string {
+	public function get_api_base_url(bool $test_mode): string {
 
 		return $test_mode ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com';
 	}
@@ -127,7 +127,7 @@ class PayPal_Connect {
 	 * @param bool $test_mode Whether to use sandbox credentials.
 	 * @return array{client_id: string, client_secret: string, merchant_id: string}
 	 */
-	protected function get_partner_credentials(bool $test_mode): array {
+	public function get_partner_credentials(bool $test_mode): array {
 
 		if ($test_mode) {
 			return [
@@ -150,7 +150,7 @@ class PayPal_Connect {
 	 * @param bool $test_mode Whether to use sandbox.
 	 * @return string|\WP_Error
 	 */
-	protected function get_partner_access_token(bool $test_mode) {
+	public function get_partner_access_token(bool $test_mode) {
 
 		$cache_key    = 'wu_pp_proxy_token_' . ($test_mode ? 'sandbox' : 'live');
 		$cached_token = get_transient($cache_key);
@@ -394,7 +394,9 @@ class PayPal_Connect {
 		$credentials = $this->get_partner_credentials($test_mode);
 
 		if (empty($credentials['merchant_id'])) {
-			// Without partner merchant ID, return basic success
+			// Without partner merchant ID, record the onboarding event and return basic success.
+			PayPal_Merchants_Table::upsert_merchant($merchant_id, $tracking_id, $test_mode);
+
 			return new \WP_REST_Response(
 				[
 					'merchantId'         => $merchant_id,
@@ -436,10 +438,16 @@ class PayPal_Connect {
 			);
 		}
 
+		// Record the successful onboarding event.
+		$verified_merchant_id = $resp_body['merchant_id'] ?? $merchant_id;
+		$verified_tracking_id = $resp_body['tracking_id'] ?? $tracking_id;
+
+		PayPal_Merchants_Table::upsert_merchant($verified_merchant_id, $verified_tracking_id, $test_mode);
+
 		return new \WP_REST_Response(
 			[
-				'merchantId'         => $resp_body['merchant_id'] ?? $merchant_id,
-				'trackingId'         => $resp_body['tracking_id'] ?? $tracking_id,
+				'merchantId'         => $verified_merchant_id,
+				'trackingId'         => $verified_tracking_id,
 				'paymentsReceivable' => $resp_body['payments_receivable'] ?? false,
 				'emailConfirmed'     => $resp_body['primary_email_confirmed'] ?? false,
 			],
@@ -519,7 +527,7 @@ class PayPal_Connect {
 	 * Handle POST /deauthorize
 	 *
 	 * Notification that a customer site has disconnected.
-	 * Used for logging/cleanup. Non-blocking from the client side.
+	 * Records the disconnect event in the analytics table and logs for auditing.
 	 *
 	 * @param \WP_REST_Request $request The request.
 	 * @return \WP_REST_Response
@@ -528,12 +536,23 @@ class PayPal_Connect {
 
 		$body = $request->get_json_params();
 
-		$site_url  = $body['siteUrl'] ?? 'unknown';
-		$test_mode = (bool) ($body['testMode'] ?? true);
-		$mode      = $test_mode ? 'sandbox' : 'live';
+		$site_url    = $body['siteUrl'] ?? 'unknown';
+		$merchant_id = $body['merchantId'] ?? '';
+		$test_mode   = (bool) ($body['testMode'] ?? true);
+		$mode        = $test_mode ? 'sandbox' : 'live';
 
-		// Log the disconnect for auditing
-		error_log(sprintf('[PayPal Connect] Site disconnected: %s (mode: %s)', $site_url, $mode));
+		// Record the disconnect event in the analytics table when a merchant ID is provided.
+		if ( ! empty($merchant_id)) {
+			PayPal_Merchants_Table::mark_disconnected($merchant_id, $test_mode);
+		}
+
+		// Log the disconnect for auditing.
+		error_log(sprintf(
+			'[PayPal Connect] Site disconnected: %s (merchant: %s, mode: %s)',
+			$site_url,
+			$merchant_id ?: 'unknown',
+			$mode
+		));
 
 		return new \WP_REST_Response(
 			['success' => true],

--- a/inc/class-paypal-merchants-table.php
+++ b/inc/class-paypal-merchants-table.php
@@ -1,0 +1,463 @@
+<?php
+/**
+ * PayPal Merchants Analytics Database Tables.
+ *
+ * Manages two tables:
+ *   - wp_wu_paypal_merchants  — one row per onboarded merchant
+ *   - wp_wu_paypal_analytics  — daily aggregated partner-fee data per merchant
+ *
+ * @package WP_Update_Server_Plugin
+ * @since 1.0.0
+ */
+
+namespace WP_Update_Server_Plugin;
+
+defined('ABSPATH') || exit;
+
+/**
+ * PayPal merchants analytics table manager.
+ */
+class PayPal_Merchants_Table {
+
+	/**
+	 * Merchants table name (without prefix).
+	 *
+	 * @var string
+	 */
+	const MERCHANTS_TABLE = 'wu_paypal_merchants';
+
+	/**
+	 * Analytics table name (without prefix).
+	 *
+	 * @var string
+	 */
+	const ANALYTICS_TABLE = 'wu_paypal_analytics';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+
+		add_action('admin_init', [$this, 'maybe_create_tables']);
+	}
+
+	/**
+	 * Get the full merchants table name with prefix.
+	 *
+	 * @return string
+	 */
+	public static function get_merchants_table(): string {
+
+		global $wpdb;
+
+		return $wpdb->prefix . self::MERCHANTS_TABLE;
+	}
+
+	/**
+	 * Get the full analytics table name with prefix.
+	 *
+	 * @return string
+	 */
+	public static function get_analytics_table(): string {
+
+		global $wpdb;
+
+		return $wpdb->prefix . self::ANALYTICS_TABLE;
+	}
+
+	/**
+	 * Create tables if they do not exist.
+	 *
+	 * @return void
+	 */
+	public function maybe_create_tables(): void {
+
+		global $wpdb;
+
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$merchants_table = self::get_merchants_table();
+		$analytics_table = self::get_analytics_table();
+
+		$merchants_exists = $wpdb->get_var(
+			$wpdb->prepare('SHOW TABLES LIKE %s', $merchants_table)
+		);
+
+		$analytics_exists = $wpdb->get_var(
+			$wpdb->prepare('SHOW TABLES LIKE %s', $analytics_table)
+		);
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		if ($merchants_exists !== $merchants_table) {
+			$sql = "CREATE TABLE {$merchants_table} (
+				id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+				merchant_id VARCHAR(50) NOT NULL,
+				tracking_id VARCHAR(100) DEFAULT NULL,
+				test_mode TINYINT(1) NOT NULL DEFAULT 0,
+				status ENUM('onboarded','active','disconnected') NOT NULL DEFAULT 'onboarded',
+				onboarded_at DATETIME NOT NULL,
+				disconnected_at DATETIME DEFAULT NULL,
+				last_transaction DATETIME DEFAULT NULL,
+				total_volume BIGINT NOT NULL DEFAULT 0,
+				currency VARCHAR(3) NOT NULL DEFAULT 'USD',
+				created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (id),
+				UNIQUE KEY merchant_id_mode (merchant_id, test_mode),
+				KEY status (status)
+			) {$charset_collate};";
+
+			dbDelta($sql);
+		}
+
+		if ($analytics_exists !== $analytics_table) {
+			$sql = "CREATE TABLE {$analytics_table} (
+				id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+				merchant_id VARCHAR(50) NOT NULL,
+				period_date DATE NOT NULL,
+				transaction_count INT UNSIGNED NOT NULL DEFAULT 0,
+				gross_volume BIGINT NOT NULL DEFAULT 0,
+				partner_fees BIGINT NOT NULL DEFAULT 0,
+				currency VARCHAR(3) NOT NULL DEFAULT 'USD',
+				PRIMARY KEY (id),
+				UNIQUE KEY merchant_period (merchant_id, period_date, currency),
+				KEY period_date (period_date)
+			) {$charset_collate};";
+
+			dbDelta($sql);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Merchant record helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Upsert a merchant record on successful onboarding.
+	 *
+	 * @param string $merchant_id PayPal merchant/payer ID.
+	 * @param string $tracking_id Our internal tracking UUID.
+	 * @param bool   $test_mode   Whether this is a sandbox merchant.
+	 * @return int|false Inserted/updated row ID or false on failure.
+	 */
+	public static function upsert_merchant(string $merchant_id, string $tracking_id, bool $test_mode) {
+
+		global $wpdb;
+
+		$table = self::get_merchants_table();
+
+		$existing = $wpdb->get_row(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT id, status FROM {$table} WHERE merchant_id = %s AND test_mode = %d",
+				$merchant_id,
+				(int) $test_mode
+			)
+		);
+
+		if ($existing) {
+			// Re-onboarding a previously disconnected merchant → set back to onboarded.
+			$wpdb->update(
+				$table,
+				[
+					'tracking_id'      => $tracking_id,
+					'status'           => 'onboarded',
+					'disconnected_at'  => null,
+					'onboarded_at'     => current_time('mysql'),
+				],
+				[
+					'merchant_id' => $merchant_id,
+					'test_mode'   => (int) $test_mode,
+				],
+				['%s', '%s', null, '%s'],
+				['%s', '%d']
+			);
+
+			return (int) $existing->id;
+		}
+
+		$result = $wpdb->insert(
+			$table,
+			[
+				'merchant_id'  => $merchant_id,
+				'tracking_id'  => $tracking_id,
+				'test_mode'    => (int) $test_mode,
+				'status'       => 'onboarded',
+				'onboarded_at' => current_time('mysql'),
+			],
+			['%s', '%s', '%d', '%s', '%s']
+		);
+
+		return $result ? $wpdb->insert_id : false;
+	}
+
+	/**
+	 * Mark a merchant as disconnected.
+	 *
+	 * @param string $merchant_id PayPal merchant/payer ID.
+	 * @param bool   $test_mode   Whether this is a sandbox merchant.
+	 * @return bool
+	 */
+	public static function mark_disconnected(string $merchant_id, bool $test_mode): bool {
+
+		global $wpdb;
+
+		$table = self::get_merchants_table();
+
+		$result = $wpdb->update(
+			$table,
+			[
+				'status'          => 'disconnected',
+				'disconnected_at' => current_time('mysql'),
+			],
+			[
+				'merchant_id' => $merchant_id,
+				'test_mode'   => (int) $test_mode,
+			],
+			['%s', '%s'],
+			['%s', '%d']
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Mark a merchant as active and update last_transaction timestamp.
+	 *
+	 * @param string $merchant_id PayPal merchant/payer ID.
+	 * @param bool   $test_mode   Whether this is a sandbox merchant.
+	 * @return bool
+	 */
+	public static function mark_active(string $merchant_id, bool $test_mode): bool {
+
+		global $wpdb;
+
+		$table = self::get_merchants_table();
+
+		$result = $wpdb->update(
+			$table,
+			[
+				'status'           => 'active',
+				'last_transaction' => current_time('mysql'),
+			],
+			[
+				'merchant_id' => $merchant_id,
+				'test_mode'   => (int) $test_mode,
+			],
+			['%s', '%s'],
+			['%s', '%d']
+		);
+
+		return false !== $result;
+	}
+
+	// -------------------------------------------------------------------------
+	// Analytics record helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Upsert a daily analytics row for a merchant.
+	 *
+	 * Amounts are stored in the smallest currency unit (e.g. cents for USD).
+	 *
+	 * @param string $merchant_id       PayPal merchant/payer ID.
+	 * @param string $period_date       Date string in YYYY-MM-DD format.
+	 * @param int    $transaction_count Number of transactions.
+	 * @param int    $gross_volume      Gross volume in smallest currency unit.
+	 * @param int    $partner_fees      Partner fees in smallest currency unit.
+	 * @param string $currency          ISO 4217 currency code.
+	 * @return bool
+	 */
+	public static function upsert_analytics(
+		string $merchant_id,
+		string $period_date,
+		int $transaction_count,
+		int $gross_volume,
+		int $partner_fees,
+		string $currency = 'USD'
+	): bool {
+
+		global $wpdb;
+
+		$table = self::get_analytics_table();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$table}
+					(merchant_id, period_date, transaction_count, gross_volume, partner_fees, currency)
+				VALUES
+					(%s, %s, %d, %d, %d, %s)
+				ON DUPLICATE KEY UPDATE
+					transaction_count = VALUES(transaction_count),
+					gross_volume      = VALUES(gross_volume),
+					partner_fees      = VALUES(partner_fees)",
+				$merchant_id,
+				$period_date,
+				$transaction_count,
+				$gross_volume,
+				$partner_fees,
+				$currency
+			)
+		);
+
+		return false !== $result;
+	}
+
+	// -------------------------------------------------------------------------
+	// Query helpers for the dashboard
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Get total merchant counts by status and mode.
+	 *
+	 * @return array{live_onboarded: int, live_active: int, live_disconnected: int, sandbox_onboarded: int, sandbox_active: int, sandbox_disconnected: int}
+	 */
+	public static function get_merchant_counts(): array {
+
+		global $wpdb;
+
+		$table = self::get_merchants_table();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			"SELECT test_mode, status, COUNT(*) as cnt FROM {$table} GROUP BY test_mode, status",
+			ARRAY_A
+		);
+
+		$counts = [
+			'live_onboarded'      => 0,
+			'live_active'         => 0,
+			'live_disconnected'   => 0,
+			'sandbox_onboarded'   => 0,
+			'sandbox_active'      => 0,
+			'sandbox_disconnected' => 0,
+		];
+
+		foreach ($rows as $row) {
+			$prefix = $row['test_mode'] ? 'sandbox' : 'live';
+			$key    = $prefix . '_' . $row['status'];
+
+			if (isset($counts[ $key ])) {
+				$counts[ $key ] = (int) $row['cnt'];
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Get aggregated platform partner fees for a period.
+	 *
+	 * @param int    $days     Number of days to look back.
+	 * @param string $currency ISO 4217 currency code.
+	 * @return array{total_transactions: int, gross_volume: int, partner_fees: int}
+	 */
+	public static function get_platform_totals(int $days = 30, string $currency = 'USD'): array {
+
+		global $wpdb;
+
+		$table = self::get_analytics_table();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT
+					SUM(transaction_count) as total_transactions,
+					SUM(gross_volume)      as gross_volume,
+					SUM(partner_fees)      as partner_fees
+				FROM {$table}
+				WHERE currency = %s
+				AND period_date >= DATE_SUB(CURDATE(), INTERVAL %d DAY)",
+				$currency,
+				$days
+			),
+			ARRAY_A
+		);
+
+		return [
+			'total_transactions' => (int) ($row['total_transactions'] ?? 0),
+			'gross_volume'       => (int) ($row['gross_volume'] ?? 0),
+			'partner_fees'       => (int) ($row['partner_fees'] ?? 0),
+		];
+	}
+
+	/**
+	 * Get per-merchant analytics summary for a period.
+	 *
+	 * @param int $days   Number of days to look back.
+	 * @param int $limit  Maximum rows to return.
+	 * @return array
+	 */
+	public static function get_merchant_analytics(int $days = 30, int $limit = 50): array {
+
+		global $wpdb;
+
+		$analytics_table = self::get_analytics_table();
+		$merchants_table = self::get_merchants_table();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					a.merchant_id,
+					m.status,
+					m.test_mode,
+					m.onboarded_at,
+					m.last_transaction,
+					SUM(a.transaction_count) as total_transactions,
+					SUM(a.gross_volume)      as gross_volume,
+					SUM(a.partner_fees)      as partner_fees,
+					a.currency
+				FROM {$analytics_table} a
+				LEFT JOIN {$merchants_table} m ON m.merchant_id = a.merchant_id AND m.test_mode = 0
+				WHERE a.period_date >= DATE_SUB(CURDATE(), INTERVAL %d DAY)
+				GROUP BY a.merchant_id, a.currency
+				ORDER BY gross_volume DESC
+				LIMIT %d",
+				$days,
+				$limit
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get recent merchant onboarding events.
+	 *
+	 * @param int $limit Maximum rows to return.
+	 * @return array
+	 */
+	public static function get_recent_merchants(int $limit = 20): array {
+
+		global $wpdb;
+
+		$table = self::get_merchants_table();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					id,
+					merchant_id,
+					tracking_id,
+					test_mode,
+					status,
+					onboarded_at,
+					disconnected_at,
+					last_transaction,
+					total_volume,
+					currency
+				FROM {$table}
+				ORDER BY onboarded_at DESC
+				LIMIT %d",
+				$limit
+			),
+			ARRAY_A
+		);
+
+		return $results ?: [];
+	}
+}

--- a/inc/class-paypal-transaction-sync.php
+++ b/inc/class-paypal-transaction-sync.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * PayPal Transaction Sync.
+ *
+ * Performs a daily sync of partner-fee transaction data from the PayPal
+ * Transaction Search API (/v1/reporting/transactions) and stores aggregated
+ * results in wp_wu_paypal_analytics.
+ *
+ * Scheduled via WP-Cron (daily). Can also be triggered manually via WP-CLI
+ * or the admin dashboard.
+ *
+ * @package WP_Update_Server_Plugin
+ * @since 1.0.0
+ */
+
+namespace WP_Update_Server_Plugin;
+
+defined('ABSPATH') || exit;
+
+/**
+ * PayPal transaction sync class.
+ */
+class PayPal_Transaction_Sync {
+
+	/**
+	 * Cron hook name.
+	 *
+	 * @var string
+	 */
+	const CRON_HOOK = 'wu_paypal_transaction_sync';
+
+	/**
+	 * Option key for last successful sync timestamp.
+	 *
+	 * @var string
+	 */
+	const LAST_SYNC_OPTION = 'wu_paypal_last_sync';
+
+	/**
+	 * Maximum date range per API request (PayPal limit: 31 days).
+	 *
+	 * @var int
+	 */
+	const MAX_DAYS_PER_REQUEST = 31;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+
+		add_action(self::CRON_HOOK, [$this, 'run_sync']);
+		add_action('admin_init', [$this, 'schedule_cron']);
+	}
+
+	/**
+	 * Schedule the daily cron job if not already scheduled.
+	 *
+	 * @return void
+	 */
+	public function schedule_cron(): void {
+
+		if ( ! wp_next_scheduled(self::CRON_HOOK)) {
+			wp_schedule_event(time(), 'daily', self::CRON_HOOK);
+		}
+	}
+
+	/**
+	 * Run the transaction sync for yesterday (default daily run).
+	 *
+	 * @param string|null $date_override Optional YYYY-MM-DD date to sync instead of yesterday.
+	 * @return array{synced: int, errors: string[]} Sync result summary.
+	 */
+	public function run_sync(?string $date_override = null): array {
+
+		$date = $date_override ?? gmdate('Y-m-d', strtotime('-1 day'));
+
+		$result = [
+			'synced' => 0,
+			'errors' => [],
+		];
+
+		// Sync live and sandbox separately.
+		foreach ([false, true] as $test_mode) {
+			$mode_result = $this->sync_for_date($date, $test_mode);
+
+			$result['synced'] += $mode_result['synced'];
+
+			if ( ! empty($mode_result['error'])) {
+				$result['errors'][] = ($test_mode ? '[sandbox] ' : '[live] ') . $mode_result['error'];
+			}
+		}
+
+		if (empty($result['errors'])) {
+			update_option(self::LAST_SYNC_OPTION, current_time('mysql'));
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Sync partner-fee transactions for a specific date and mode.
+	 *
+	 * @param string $date      Date in YYYY-MM-DD format.
+	 * @param bool   $test_mode Whether to use sandbox credentials.
+	 * @return array{synced: int, error: string}
+	 */
+	protected function sync_for_date(string $date, bool $test_mode): array {
+
+		$result = ['synced' => 0, 'error' => ''];
+
+		// Resolve partner credentials via PayPal_Connect.
+		$connect     = new PayPal_Connect();
+		$access_token = $connect->get_partner_access_token($test_mode);
+
+		if (is_wp_error($access_token)) {
+			$result['error'] = $access_token->get_error_message();
+
+			return $result;
+		}
+
+		$credentials = $connect->get_partner_credentials($test_mode);
+
+		if (empty($credentials['merchant_id'])) {
+			// Partner merchant ID required for transaction search.
+			$result['error'] = 'Partner merchant ID not configured — cannot query Transaction Search API.';
+
+			return $result;
+		}
+
+		$api_base = $connect->get_api_base_url($test_mode);
+
+		// Build date range: full UTC day.
+		$start_time = $date . 'T00:00:00-0000';
+		$end_time   = $date . 'T23:59:59-0000';
+
+		$page       = 1;
+		$page_size  = 500;
+		$aggregated = [];
+
+		do {
+			$url = add_query_arg(
+				[
+					'start_date'        => $start_time,
+					'end_date'          => $end_time,
+					'transaction_type'  => 'T0007', // Partner fee transactions
+					'fields'            => 'transaction_info,payer_info',
+					'page_size'         => $page_size,
+					'page'              => $page,
+				],
+				$api_base . '/v1/reporting/transactions'
+			);
+
+			$response = wp_remote_get(
+				$url,
+				[
+					'headers' => [
+						'Authorization'                 => 'Bearer ' . $access_token,
+						'Content-Type'                  => 'application/json',
+						'PayPal-Partner-Attribution-Id' => PayPal_Connect::BN_CODE,
+					],
+					'timeout' => 30,
+				]
+			);
+
+			if (is_wp_error($response)) {
+				$result['error'] = 'HTTP error: ' . $response->get_error_message();
+
+				return $result;
+			}
+
+			$resp_code = wp_remote_retrieve_response_code($response);
+			$resp_body = json_decode(wp_remote_retrieve_body($response), true);
+
+			if (200 !== $resp_code) {
+				// 403 typically means the partner doesn't have Transaction Search scope yet.
+				if (403 === $resp_code) {
+					$result['error'] = 'Transaction Search API access not granted for this partner account (HTTP 403). Request TRANSACTION_SEARCH scope from PayPal.';
+				} else {
+					$result['error'] = sprintf(
+						'Transaction Search API returned HTTP %d: %s',
+						$resp_code,
+						$resp_body['message'] ?? 'unknown error'
+					);
+				}
+
+				return $result;
+			}
+
+			$transactions = $resp_body['transaction_details'] ?? [];
+
+			foreach ($transactions as $txn) {
+				$info        = $txn['transaction_info'] ?? [];
+				$payer_info  = $txn['payer_info'] ?? [];
+				$merchant_id = $payer_info['payer_id'] ?? '';
+
+				if (empty($merchant_id)) {
+					continue;
+				}
+
+				$amount_value = (float) ($info['transaction_amount']['value'] ?? 0);
+				$fee_value    = (float) ($info['fee_amount']['value'] ?? 0);
+				$currency     = $info['transaction_amount']['currency_code'] ?? 'USD';
+
+				// Convert to smallest unit (cents).
+				$amount_cents = (int) round(abs($amount_value) * 100);
+				$fee_cents    = (int) round(abs($fee_value) * 100);
+
+				$key = $merchant_id . '|' . $currency;
+
+				if ( ! isset($aggregated[ $key ])) {
+					$aggregated[ $key ] = [
+						'merchant_id'       => $merchant_id,
+						'currency'          => $currency,
+						'transaction_count' => 0,
+						'gross_volume'      => 0,
+						'partner_fees'      => 0,
+					];
+				}
+
+				$aggregated[ $key ]['transaction_count']++;
+				$aggregated[ $key ]['gross_volume'] += $amount_cents;
+				$aggregated[ $key ]['partner_fees'] += $fee_cents;
+			}
+
+			$total_pages = (int) ($resp_body['total_pages'] ?? 1);
+			$page++;
+
+		} while ($page <= $total_pages);
+
+		// Persist aggregated rows.
+		foreach ($aggregated as $row) {
+			$saved = PayPal_Merchants_Table::upsert_analytics(
+				$row['merchant_id'],
+				$date,
+				$row['transaction_count'],
+				$row['gross_volume'],
+				$row['partner_fees'],
+				$row['currency']
+			);
+
+			if ($saved) {
+				// Mark merchant as active since we have transaction data.
+				PayPal_Merchants_Table::mark_active($row['merchant_id'], $test_mode);
+				$result['synced']++;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get the timestamp of the last successful sync.
+	 *
+	 * @return string|false MySQL datetime string or false if never synced.
+	 */
+	public static function get_last_sync_time() {
+
+		return get_option(self::LAST_SYNC_OPTION, false);
+	}
+}

--- a/inc/class-telemetry-admin.php
+++ b/inc/class-telemetry-admin.php
@@ -87,6 +87,13 @@ class Telemetry_Admin {
 		$passive_wp_versions   = Passive_Installs_Table::get_wp_version_distribution($days);
 		$passive_recent        = Passive_Installs_Table::get_recent_installs(20);
 
+		// PayPal Connect analytics data.
+		$paypal_merchant_counts  = PayPal_Merchants_Table::get_merchant_counts();
+		$paypal_platform_totals  = PayPal_Merchants_Table::get_platform_totals($days);
+		$paypal_merchant_details = PayPal_Merchants_Table::get_merchant_analytics($days, 20);
+		$paypal_recent_merchants = PayPal_Merchants_Table::get_recent_merchants(20);
+		$paypal_last_sync        = PayPal_Transaction_Sync::get_last_sync_time();
+
 		?>
 		<div class="wrap wu-telemetry-dashboard">
 			<h1><?php esc_html_e('Ultimate Multisite Telemetry Dashboard', 'wp-update-server-plugin'); ?></h1>
@@ -142,27 +149,224 @@ class Telemetry_Admin {
 					<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($passive_total)); ?></div>
 					<div class="wu-telemetry-card-label"><?php esc_html_e('unique sites ever seen', 'wp-update-server-plugin'); ?></div>
 				</div>
-				<div class="wu-telemetry-card wu-telemetry-card--passive">
-					<h3><?php esc_html_e('Authenticated Passive', 'wp-update-server-plugin'); ?></h3>
-					<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($passive_authenticated)); ?></div>
-					<div class="wu-telemetry-card-label">
-						<?php
-						printf(
-							/* translators: %d is the number of days */
-							esc_html__('with valid token in last %d days', 'wp-update-server-plugin'),
-							esc_html($days)
-						);
-						?>
-					</div>
-				</div>
-				<div class="wu-telemetry-card">
-					<h3><?php esc_html_e('Error Reports', 'wp-update-server-plugin'); ?></h3>
-					<div class="wu-telemetry-card-value"><?php echo esc_html(count($recent_errors)); ?></div>
-					<div class="wu-telemetry-card-label"><?php esc_html_e('recent errors', 'wp-update-server-plugin'); ?></div>
+			<div class="wu-telemetry-card wu-telemetry-card--passive">
+				<h3><?php esc_html_e('Authenticated Passive', 'wp-update-server-plugin'); ?></h3>
+				<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($passive_authenticated)); ?></div>
+				<div class="wu-telemetry-card-label">
+					<?php
+					printf(
+						/* translators: %d is the number of days */
+						esc_html__('with valid token in last %d days', 'wp-update-server-plugin'),
+						esc_html($days)
+					);
+					?>
 				</div>
 			</div>
+			<div class="wu-telemetry-card">
+				<h3><?php esc_html_e('Error Reports', 'wp-update-server-plugin'); ?></h3>
+				<div class="wu-telemetry-card-value"><?php echo esc_html(count($recent_errors)); ?></div>
+				<div class="wu-telemetry-card-label"><?php esc_html_e('recent errors', 'wp-update-server-plugin'); ?></div>
+			</div>
+			<div class="wu-telemetry-card wu-telemetry-card--paypal">
+				<h3><?php esc_html_e('PayPal Merchants (Live)', 'wp-update-server-plugin'); ?></h3>
+				<div class="wu-telemetry-card-value"><?php echo esc_html(number_format($paypal_merchant_counts['live_onboarded'] + $paypal_merchant_counts['live_active'])); ?></div>
+				<div class="wu-telemetry-card-label"><?php esc_html_e('onboarded / active', 'wp-update-server-plugin'); ?></div>
+			</div>
+			<div class="wu-telemetry-card wu-telemetry-card--paypal">
+				<h3><?php esc_html_e('PayPal Partner Fees', 'wp-update-server-plugin'); ?></h3>
+				<?php $fees_display = $paypal_platform_totals['partner_fees'] > 0 ? '$' . number_format($paypal_platform_totals['partner_fees'] / 100, 2) : '—'; ?>
+				<div class="wu-telemetry-card-value"><?php echo esc_html($fees_display); ?></div>
+				<div class="wu-telemetry-card-label">
+					<?php
+					printf(
+						/* translators: %d is the number of days */
+						esc_html__('last %d days (USD)', 'wp-update-server-plugin'),
+						esc_html($days)
+					);
+					?>
+				</div>
+			</div>
+		</div>
 
-			<!-- Passive Install Tracking -->
+		<!-- PayPal Connect Analytics -->
+		<h2><?php esc_html_e('PayPal Connect Analytics', 'wp-update-server-plugin'); ?></h2>
+		<p class="description">
+			<?php esc_html_e('Merchant onboarding events and partner fee data from the PayPal Connect proxy.', 'wp-update-server-plugin'); ?>
+			<?php if ($paypal_last_sync) : ?>
+				<?php
+				printf(
+					/* translators: %s is the datetime of last sync */
+					esc_html__('Last transaction sync: %s.', 'wp-update-server-plugin'),
+					esc_html($paypal_last_sync)
+				);
+				?>
+			<?php else : ?>
+				<?php esc_html_e('Transaction sync has not run yet (requires PayPal Transaction Search API access).', 'wp-update-server-plugin'); ?>
+			<?php endif; ?>
+		</p>
+
+		<div class="wu-telemetry-grid">
+			<!-- Merchant Status Summary -->
+			<div class="wu-telemetry-section">
+				<h2><?php esc_html_e('Merchant Status', 'wp-update-server-plugin'); ?></h2>
+				<table class="wp-list-table widefat fixed striped">
+					<thead>
+						<tr>
+							<th><?php esc_html_e('Mode', 'wp-update-server-plugin'); ?></th>
+							<th><?php esc_html_e('Onboarded', 'wp-update-server-plugin'); ?></th>
+							<th><?php esc_html_e('Active', 'wp-update-server-plugin'); ?></th>
+							<th><?php esc_html_e('Disconnected', 'wp-update-server-plugin'); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><?php esc_html_e('Live', 'wp-update-server-plugin'); ?></td>
+							<td><?php echo esc_html(number_format($paypal_merchant_counts['live_onboarded'])); ?></td>
+							<td><?php echo esc_html(number_format($paypal_merchant_counts['live_active'])); ?></td>
+							<td><?php echo esc_html(number_format($paypal_merchant_counts['live_disconnected'])); ?></td>
+						</tr>
+						<tr>
+							<td><?php esc_html_e('Sandbox', 'wp-update-server-plugin'); ?></td>
+							<td><?php echo esc_html(number_format($paypal_merchant_counts['sandbox_onboarded'])); ?></td>
+							<td><?php echo esc_html(number_format($paypal_merchant_counts['sandbox_active'])); ?></td>
+							<td><?php echo esc_html(number_format($paypal_merchant_counts['sandbox_disconnected'])); ?></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<!-- Platform Totals -->
+			<div class="wu-telemetry-section">
+				<h2>
+					<?php
+					printf(
+						/* translators: %d is the number of days */
+						esc_html__('Platform Totals (Last %d Days)', 'wp-update-server-plugin'),
+						esc_html($days)
+					);
+					?>
+				</h2>
+				<table class="wp-list-table widefat fixed striped">
+					<thead>
+						<tr>
+							<th><?php esc_html_e('Metric', 'wp-update-server-plugin'); ?></th>
+							<th><?php esc_html_e('Value', 'wp-update-server-plugin'); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><?php esc_html_e('Transactions', 'wp-update-server-plugin'); ?></td>
+							<td><?php echo esc_html(number_format($paypal_platform_totals['total_transactions'])); ?></td>
+						</tr>
+						<tr>
+							<td><?php esc_html_e('Gross Volume (USD)', 'wp-update-server-plugin'); ?></td>
+							<td>$<?php echo esc_html(number_format($paypal_platform_totals['gross_volume'] / 100, 2)); ?></td>
+						</tr>
+						<tr>
+							<td><?php esc_html_e('Partner Fees (USD)', 'wp-update-server-plugin'); ?></td>
+							<td>$<?php echo esc_html(number_format($paypal_platform_totals['partner_fees'] / 100, 2)); ?></td>
+						</tr>
+					</tbody>
+				</table>
+				<?php if (0 === $paypal_platform_totals['total_transactions']) : ?>
+					<p class="description" style="margin-top: 10px;">
+						<?php esc_html_e('No transaction data yet. Data populates after the daily sync runs (requires PayPal Transaction Search API access).', 'wp-update-server-plugin'); ?>
+					</p>
+				<?php endif; ?>
+			</div>
+		</div>
+
+		<!-- Per-Merchant Analytics -->
+		<?php if ( ! empty($paypal_merchant_details)) : ?>
+		<div class="wu-telemetry-section wu-telemetry-full-width" style="margin-bottom: 20px;">
+			<h2>
+				<?php
+				printf(
+					/* translators: %d is the number of days */
+					esc_html__('Per-Merchant Analytics (Last %d Days)', 'wp-update-server-plugin'),
+					esc_html($days)
+				);
+				?>
+			</h2>
+			<table class="wp-list-table widefat fixed striped">
+				<thead>
+					<tr>
+						<th style="width: 20%;"><?php esc_html_e('Merchant ID', 'wp-update-server-plugin'); ?></th>
+						<th style="width: 10%;"><?php esc_html_e('Status', 'wp-update-server-plugin'); ?></th>
+						<th style="width: 8%;"><?php esc_html_e('Mode', 'wp-update-server-plugin'); ?></th>
+						<th style="width: 10%;"><?php esc_html_e('Transactions', 'wp-update-server-plugin'); ?></th>
+						<th style="width: 15%;"><?php esc_html_e('Gross Volume', 'wp-update-server-plugin'); ?></th>
+						<th style="width: 15%;"><?php esc_html_e('Partner Fees', 'wp-update-server-plugin'); ?></th>
+						<th style="width: 10%;"><?php esc_html_e('Currency', 'wp-update-server-plugin'); ?></th>
+						<th style="width: 12%;"><?php esc_html_e('Last Transaction', 'wp-update-server-plugin'); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ($paypal_merchant_details as $row) : ?>
+						<tr>
+							<td><code><?php echo esc_html($row['merchant_id']); ?></code></td>
+							<td><?php echo esc_html(ucfirst($row['status'] ?? '—')); ?></td>
+							<td>
+								<?php if ($row['test_mode']) : ?>
+									<span class="wu-badge wu-badge--sandbox"><?php esc_html_e('Sandbox', 'wp-update-server-plugin'); ?></span>
+								<?php else : ?>
+									<span class="wu-badge wu-badge--live"><?php esc_html_e('Live', 'wp-update-server-plugin'); ?></span>
+								<?php endif; ?>
+							</td>
+							<td><?php echo esc_html(number_format((int) $row['total_transactions'])); ?></td>
+							<td>$<?php echo esc_html(number_format((int) $row['gross_volume'] / 100, 2)); ?></td>
+							<td>$<?php echo esc_html(number_format((int) $row['partner_fees'] / 100, 2)); ?></td>
+							<td><?php echo esc_html($row['currency']); ?></td>
+							<td><?php echo esc_html($row['last_transaction'] ?: '—'); ?></td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
+		<?php endif; ?>
+
+		<!-- Recent Merchant Onboarding Events -->
+		<div class="wu-telemetry-section wu-telemetry-full-width" style="margin-bottom: 20px;">
+			<h2><?php esc_html_e('Recent Merchant Onboarding Events', 'wp-update-server-plugin'); ?></h2>
+			<?php if ( ! empty($paypal_recent_merchants)) : ?>
+				<table class="wp-list-table widefat fixed striped">
+					<thead>
+						<tr>
+							<th style="width: 20%;"><?php esc_html_e('Merchant ID', 'wp-update-server-plugin'); ?></th>
+							<th style="width: 20%;"><?php esc_html_e('Tracking ID', 'wp-update-server-plugin'); ?></th>
+							<th style="width: 8%;"><?php esc_html_e('Mode', 'wp-update-server-plugin'); ?></th>
+							<th style="width: 10%;"><?php esc_html_e('Status', 'wp-update-server-plugin'); ?></th>
+							<th style="width: 14%;"><?php esc_html_e('Onboarded At', 'wp-update-server-plugin'); ?></th>
+							<th style="width: 14%;"><?php esc_html_e('Disconnected At', 'wp-update-server-plugin'); ?></th>
+							<th style="width: 14%;"><?php esc_html_e('Last Transaction', 'wp-update-server-plugin'); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ($paypal_recent_merchants as $row) : ?>
+							<tr>
+								<td><code><?php echo esc_html($row['merchant_id']); ?></code></td>
+								<td><code style="font-size: 11px;"><?php echo esc_html($row['tracking_id'] ?: '—'); ?></code></td>
+								<td>
+									<?php if ($row['test_mode']) : ?>
+										<span class="wu-badge wu-badge--sandbox"><?php esc_html_e('Sandbox', 'wp-update-server-plugin'); ?></span>
+									<?php else : ?>
+										<span class="wu-badge wu-badge--live"><?php esc_html_e('Live', 'wp-update-server-plugin'); ?></span>
+									<?php endif; ?>
+								</td>
+								<td><?php echo esc_html(ucfirst($row['status'])); ?></td>
+								<td><?php echo esc_html($row['onboarded_at']); ?></td>
+								<td><?php echo esc_html($row['disconnected_at'] ?: '—'); ?></td>
+								<td><?php echo esc_html($row['last_transaction'] ?: '—'); ?></td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			<?php else : ?>
+				<p><?php esc_html_e('No merchant onboarding events recorded yet. Events will appear after merchants complete the PayPal Connect onboarding flow.', 'wp-update-server-plugin'); ?></p>
+			<?php endif; ?>
+		</div>
+
+		<!-- Passive Install Tracking -->
 			<h2><?php esc_html_e('Passive Install Tracking', 'wp-update-server-plugin'); ?></h2>
 			<p class="description">
 				<?php esc_html_e('Recorded from update check requests (equivalent to server access log data). No opt-in required.', 'wp-update-server-plugin'); ?>
@@ -597,6 +801,21 @@ class Telemetry_Admin {
 			.wu-badge--no {
 				background: #f3f4f6;
 				color: #6b7280;
+			}
+			.wu-telemetry-card--paypal {
+				border-color: #003087;
+				background: #f0f4ff;
+			}
+			.wu-telemetry-card--paypal .wu-telemetry-card-value {
+				color: #003087;
+			}
+			.wu-badge--live {
+				background: #dbeafe;
+				color: #1e40af;
+			}
+			.wu-badge--sandbox {
+				background: #fef9c3;
+				color: #854d0e;
 			}
 		</style>
 		<?php

--- a/wp-update-server-plugin.php
+++ b/wp-update-server-plugin.php
@@ -54,9 +54,13 @@ $wp_update_server_plugin_downloads_page       = new \WP_Update_Server_Plugin\Dow
 // Release notification components
 $wp_update_server_plugin_changelog_manager = new \WP_Update_Server_Plugin\Changelog_Manager();
 
-// PayPal Connect proxy (mirrors Stripe Connect proxy pattern)
+// PayPal Connect proxy and analytics (mirrors Stripe Connect proxy pattern)
+require_once __DIR__ . '/inc/class-paypal-merchants-table.php';
+require_once __DIR__ . '/inc/class-paypal-transaction-sync.php';
 require_once __DIR__ . '/inc/class-paypal-connect.php';
-$wp_update_server_plugin_paypal_connect = new \WP_Update_Server_Plugin\PayPal_Connect();
+$wp_update_server_plugin_paypal_merchants_table = new \WP_Update_Server_Plugin\PayPal_Merchants_Table();
+$wp_update_server_plugin_paypal_transaction_sync = new \WP_Update_Server_Plugin\PayPal_Transaction_Sync();
+$wp_update_server_plugin_paypal_connect          = new \WP_Update_Server_Plugin\PayPal_Connect();
 
 add_action('woocommerce_loaded', function () {
 	require_once __DIR__ . '/inc/class-release-notifier.php';


### PR DESCRIPTION
## Summary

- Adds `PayPal_Merchants_Table` class managing two new DB tables (`wp_wu_paypal_merchants`, `wp_wu_paypal_analytics`) auto-created via `dbDelta` on `admin_init`
- Adds `PayPal_Transaction_Sync` class for daily WP-Cron sync of partner-fee data from the PayPal Transaction Search API (`/v1/reporting/transactions`)
- Captures onboarding events in `handle_oauth_verify` (upserts merchant record) and disconnect events in `handle_deauthorize` (marks merchant disconnected, accepts optional `merchantId` field)
- Extends the Telemetry Admin dashboard with a full PayPal Connect Analytics section: merchant status by mode, platform totals (transactions/volume/fees), per-merchant analytics table, and recent onboarding events
- Adds PayPal overview cards (merchant count + partner fees) to the existing overview cards row

## Runtime Testing

- **Risk classification:** Medium — new DB tables, REST endpoint side-effects, admin dashboard rendering
- **Testing level:** self-assessed (no dev environment available for live PayPal API calls)
- **Code review:** All DB queries use `$wpdb->prepare()`, all output uses `esc_html()`, table creation uses `dbDelta()` following the existing pattern in `Telemetry_Table`
- **Graceful degradation:** Transaction sync returns a clear error message when Transaction Search API access is not granted (HTTP 403), and the dashboard shows "—" / zero values when no data exists yet

## Files Changed

- `inc/class-paypal-merchants-table.php` — new: DB table manager + query helpers
- `inc/class-paypal-transaction-sync.php` — new: daily cron sync via PayPal Reporting API
- `inc/class-paypal-connect.php` — capture onboard/disconnect events; promote 3 methods from `protected` to `public`
- `inc/class-telemetry-admin.php` — add PayPal analytics section to dashboard
- `wp-update-server-plugin.php` — register new classes

Closes #7