### PR TITLE
fix(paypal): correct BN code to ULTIMATE_SP_PPCP

### DIFF
--- a/inc/class-paypal-connect.php
+++ b/inc/class-paypal-connect.php
@@ -40,7 +40,7 @@ class PayPal_Connect {
 	 *
 	 * @var string
 	 */
-	const BN_CODE = 'UltimateMultisite_SP_PPCP';
+	const BN_CODE = 'ULTIMATE_SP_PPCP';
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
## Summary

- Corrects the `BN_CODE` constant in `PayPal_Connect` from `UltimateMultisite_SP_PPCP` to `ULTIMATE_SP_PPCP`
- Aligns the proxy server BN code with the PayPal-assigned partner attribution ID and the plugin's own `$bn_code` value

## Changes

- `inc/class-paypal-connect.php` line 43: `BN_CODE` constant corrected

## Testing

- PHP syntax check: `php -l` passes with no errors
- Change is a single string constant correction; no logic altered
- Risk level: **Low** (string constant, no runtime logic change)

## Runtime Testing

- Level: `self-assessed` (Low risk — string constant correction only)
- PHP syntax validated via `php -l`

Closes #22


---
[aidevops.sh](https://aidevops.sh) v3.5.556 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PayPal integration identifier for partner attribution tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->