### PR TITLE
GH#21: fix(paypal): Add ACCESS_MERCHANT_INFORMATION to partner referral features

### DIFF
--- a/inc/class-paypal-connect.php
+++ b/inc/class-paypal-connect.php
@@ -270,6 +270,7 @@ class PayPal_Connect {
 									'REFUND',
 									'PARTNER_FEE',
 									'DELAY_FUNDS_DISBURSEMENT',
+									'ACCESS_MERCHANT_INFORMATION',
 								],
 							],
 						],


### PR DESCRIPTION
## Summary

Add `ACCESS_MERCHANT_INFORMATION` to the PayPal partner-referrals features array, as required by PayPal's review process.

## Changes

- `inc/class-paypal-connect.php`: Added `ACCESS_MERCHANT_INFORMATION` to the `features` array in the partner-referrals API call body

## Testing

- Self-assessed (low risk): single string addition to a static array, no logic change
- The features array is passed directly to PayPal's `/v2/customer/partner-referrals` endpoint

## Runtime Testing

**Risk level:** Low — static array value addition, no conditional logic, no side effects.
**Verification:** Code review confirms correct placement within `third_party_details.features` array.

Closes #21


---
[aidevops.sh](https://aidevops.sh) v3.5.556 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 2m on this as a headless worker.