### PR TITLE
fix: assign Release_Notifier to global to prevent premature garbage collection

### DIFF
--- a/wp-update-server-plugin.php
+++ b/wp-update-server-plugin.php
@@ -72,5 +72,10 @@ $wp_update_server_plugin_stripe_analytics_admin = new \WP_Update_Server_Plugin\S
 
 add_action('woocommerce_loaded', function () {
 	require_once __DIR__ . '/inc/class-release-notifier.php';
-	$wp_update_server_plugin_release_notifier  = new \WP_Update_Server_Plugin\Release_Notifier();
+	// Assign to a global so the object is not garbage-collected when the closure returns.
+	// The Release_Notifier constructor registers hooks via [$this, 'method'] callbacks —
+	// WordPress holds a reference to those, but assigning to a global makes the lifetime
+	// explicit and avoids relying on that implementation detail.
+	global $wp_update_server_plugin_release_notifier;
+	$wp_update_server_plugin_release_notifier = new \WP_Update_Server_Plugin\Release_Notifier();
 });


### PR DESCRIPTION
## Problem

`Release_Notifier` was instantiated inside a `woocommerce_loaded` closure and assigned to a local variable:

```php
add_action('woocommerce_loaded', function () {
    require_once __DIR__ . '/inc/class-release-notifier.php';
    $wp_update_server_plugin_release_notifier = new \WP_Update_Server_Plugin\Release_Notifier();
});
```

When the closure returns, the local variable goes out of scope. PHP's garbage collector can destroy the object. The constructor registers hooks via `[$this, 'method']` array callbacks — WordPress holds a reference to those callbacks which keeps the object alive in practice, but this is an implementation detail of WordPress's hook system that should not be relied upon.

All other components in this plugin are assigned to global variables for explicit lifetime management. `Release_Notifier` was the only exception.

## Fix

Declare `global $wp_update_server_plugin_release_notifier` inside the closure before assigning, consistent with how all other plugin components are managed.

## Changes

- `wp-update-server-plugin.php`: assign `Release_Notifier` instance to a global variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced object persistence for plugin release notification components, improving system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->