### PR TITLE
fix: feature-detect GLOB_BRACE for musl-libc PHP builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "type": "wordpress-plugin",
     "require": {
-        "yahnis-elsts/wp-update-server": "^2.0"
+        "yahnis-elsts/wp-update-server": "^2.0",
+        "cweagans/composer-patches": "^1.7"
     },
     "require-dev": {
         "szepeviktor/phpstan-wordpress": "^2.0",
@@ -22,7 +23,16 @@
     },
     "config": {
         "allow-plugins": {
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "cweagans/composer-patches": true
         }
+    },
+    "extra": {
+        "patches": {
+            "yahnis-elsts/wp-update-server": {
+                "Feature-detect GLOB_BRACE for musl-libc PHP builds (Alpine, static FrankenPHP)": "patches/wp-update-server-glob-brace-musl.patch"
+            }
+        },
+        "composer-exit-on-patch-failure": true
     }
 }

--- a/patches/wp-update-server-glob-brace-musl.patch
+++ b/patches/wp-update-server-glob-brace-musl.patch
@@ -1,0 +1,44 @@
+Subject: Feature-detect GLOB_BRACE for musl-libc PHP builds
+
+GLOB_BRACE is undefined on PHP builds linked against musl libc
+(e.g. Alpine, static FrankenPHP releases). Referencing the constant
+there causes a fatal "Undefined constant" Error in PHP 8, breaking
+update API responses whenever findFirstAsset() runs.
+
+When GLOB_BRACE is available, behaviour is identical. When it is not,
+fall back to one glob() call per extension and merge the results.
+
+--- a/includes/Wpup/UpdateServer.php
++++ b/includes/Wpup/UpdateServer.php
+@@ -385,13 +385,28 @@ class Wpup_UpdateServer {
+ 	) {
+ 		$pattern = $this->assetDirectories[$assetType] . '/' . $package->slug . $suffix;
+ 
++		//GLOB_BRACE is not defined on every libc (e.g. musl, used by Alpine/static
++		//FrankenPHP builds). When it's missing, fall back to one glob() call per
++		//extension and merge the results. Behaviour is identical otherwise.
+ 		if ( is_array($extensions) ) {
+-			$extensionPattern = '{' . implode(',', $extensions) . '}';
++			if ( defined('GLOB_BRACE') ) {
++				$assets = glob(
++					$pattern . '.{' . implode(',', $extensions) . '}',
++					GLOB_BRACE | GLOB_NOESCAPE
++				);
++			} else {
++				$assets = array();
++				foreach ($extensions as $extension) {
++					$matches = glob($pattern . '.' . $extension, GLOB_NOESCAPE);
++					if ( !empty($matches) ) {
++						$assets = array_merge($assets, $matches);
++					}
++				}
++			}
+ 		} else {
+-			$extensionPattern = $extensions;
++			$assets = glob($pattern . '.' . $extensions, GLOB_NOESCAPE);
+ 		}
+ 
+-		$assets = glob($pattern . '.' . $extensionPattern, GLOB_BRACE | GLOB_NOESCAPE);
+ 		if ( !empty($assets) ) {
+ 			$firstFile = basename(reset($assets));
+ 			return $this->generateAssetUrl($assetType, $firstFile);

--- a/vendor/yahnis-elsts/wp-update-server/includes/Wpup/UpdateServer.php
+++ b/vendor/yahnis-elsts/wp-update-server/includes/Wpup/UpdateServer.php
@@ -385,13 +385,28 @@ class Wpup_UpdateServer {
 	) {
 		$pattern = $this->assetDirectories[$assetType] . '/' . $package->slug . $suffix;
 
+		//GLOB_BRACE is not defined on every libc (e.g. musl, used by Alpine/static
+		//FrankenPHP builds). When it's missing, fall back to one glob() call per
+		//extension and merge the results. Behaviour is identical otherwise.
 		if ( is_array($extensions) ) {
-			$extensionPattern = '{' . implode(',', $extensions) . '}';
+			if ( defined('GLOB_BRACE') ) {
+				$assets = glob(
+					$pattern . '.{' . implode(',', $extensions) . '}',
+					GLOB_BRACE | GLOB_NOESCAPE
+				);
+			} else {
+				$assets = array();
+				foreach ($extensions as $extension) {
+					$matches = glob($pattern . '.' . $extension, GLOB_NOESCAPE);
+					if ( !empty($matches) ) {
+						$assets = array_merge($assets, $matches);
+					}
+				}
+			}
 		} else {
-			$extensionPattern = $extensions;
+			$assets = glob($pattern . '.' . $extensions, GLOB_NOESCAPE);
 		}
 
-		$assets = glob($pattern . '.' . $extensionPattern, GLOB_BRACE | GLOB_NOESCAPE);
 		if ( !empty($assets) ) {
 			$firstFile = basename(reset($assets));
 			return $this->generateAssetUrl($assetType, $firstFile);


### PR DESCRIPTION
## Summary

- Patches the vendored `yahnis-elsts/wp-update-server` library to feature-detect `GLOB_BRACE` instead of referencing it unconditionally.
- Wires the patch through `cweagans/composer-patches` so it re-applies on every `composer install`/`update`.
- Commits the patched `vendor/.../UpdateServer.php` so existing deployments that ship `vendor/` as-is (this plugin does) pick up the fix immediately.

## Why

`GLOB_BRACE` is **undefined** on PHP builds linked against **musl libc** — for example Alpine images and the official static **FrankenPHP** binary releases. In PHP 8, referencing an undefined constant is a **fatal `Error`**, not a notice, so every call to `Wpup_UpdateServer::findFirstAsset()` crashes the update API response when it tries to resolve a plugin banner or icon.

Observed in local debug.log (FrankenPHP v1.4.4, PHP 8.4.5, static musl build):

```
[13-May-2026 07:31:24 UTC] PHP Fatal error:  Uncaught Error: Undefined constant "GLOB_BRACE"
  in .../vendor/yahnis-elsts/wp-update-server/includes/Wpup/UpdateServer.php:394
```

## How

Inside `findFirstAsset()`:

- When `GLOB_BRACE` **is** defined, behaviour is identical to upstream.
- When it is **not** defined, fall back to one `glob()` call per extension and merge results.
- The string-extension branch drops the no-longer-needed `GLOB_BRACE` flag (it was meaningless when no braces were present).

The same fix is being proposed upstream to `YahnisElsts/wp-update-server`. Once accepted, the local patch can be removed.

## Verification

- `php -l` clean on patched file (both glibc system PHP and musl FrankenPHP).
- Smoke test exercising all three branches (array+brace, array+fallback, string-extension) returns identical results under glibc system PHP and musl FrankenPHP.
- Live: hit `?update_action=get_metadata&update_slug=...` on the local install — returned the expected `404 Package not found` (instead of fatal-ing); no new `GLOB_BRACE` lines in `debug.log` since the patch was applied (>40 min, multiple update requests).
- Patch applies cleanly to upstream `master` via `git apply --check`.

## Test plan

```bash
# Reproduce on a musl-libc PHP build (any Alpine container or static FrankenPHP):
php -r 'var_dump(defined("GLOB_BRACE"));'   # => bool(false)

# Before the patch: update API requests fatal in debug.log.
# After the patch: requests respond normally.
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 14h 35m and 15,815 tokens on this as a headless worker.
